### PR TITLE
PROP-1567 Initial attempt at a CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,8 @@ jobs:
           command: sbt test
       - *cache_save
 
+workflows:
+  version: 2
   master-build:
     jobs:
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,6 @@ docker_sbt: &docker_sbt
   environment:
     JVM_OPTS: -Xmx3200m
 
-determine_subproject: &determine_subproject
-  run:
-    command: |
-      version=`git describe --always | grep -Po '[0-9\.-]+'`
-      project=`git describe --always | grep -Po '^\S+(?=/)'`
-      echo "export VERSION=${version}" >> $BASH_ENV
-      echo "export PROJECT=${project}" >> $BASH_ENV
-
 cache_save: &cache_save
   save_cache:
     paths:
@@ -33,16 +25,14 @@ cache_restore: &cache_restore
       - v1-{{ checksum "build.sbt" }}
       - v1-
 jobs:
-
   release:
     <<: *docker_sbt
     steps:
       - checkout
       - *cache_restore
-      - *determine_subproject
       - run:
           name: Release
-          command: sbt ';project '${PROJECT}' ;set version := "'${VERSION}'"; test; publish'
+          command: sbt ';set version in ThisBuild := "'`git describe`'"; test; publish'
       - *cache_save
 
   test:
@@ -51,7 +41,7 @@ jobs:
       - checkout
       - *cache_restore
       - run:
-          name: Test all subprojects
+          name: Test
           command: sbt test
       - *cache_save
 
@@ -60,8 +50,7 @@ workflows:
   master-build:
     jobs:
       - release:
-          filters: {tags: {only: /\S+\/([0-9\.-]+)/}}
-
+          filters: {tags: {only: /([0-9\.]+)/}}
   pr-build:
     jobs:
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,67 @@
+version: 2
+
+docker_sbt: &docker_sbt
+  docker:
+    - image: circleci/openjdk:8-jdk
+      environment:
+        DEBIAN_FRONTEND: noninteractive
+        SBT_OPTS: -Xms256m -Xmx756G -XX:+CMSClassUnloadingEnabled -XX:+UseSerialGC -XX:MaxMetaspaceSize=2G
+        DISABLE_SCALAFMT: true
+  working_directory: ~/repo
+  environment:
+    JVM_OPTS: -Xmx3200m
+
+determine_subproject: &determine_subproject
+  run:
+    command: |
+      version=`git describe --always | grep -Po '[0-9\.-]+'`
+      project=`git describe --always | grep -Po '^\S+(?=/)'`
+      echo "export VERSION=${version}" >> $BASH_ENV
+      echo "export PROJECT=${project}" >> $BASH_ENV
+
+cache_save: &cache_save
+  save_cache:
+    paths:
+      - ~/.m2
+      - ~/.sbt
+      - ~/.ivy2/cache
+    key: v1-{{ checksum "build.sbt" }}
+
+cache_restore: &cache_restore
+  restore_cache:
+    keys:
+      - v1-{{ checksum "build.sbt" }}
+      - v1-
+jobs:
+
+  release:
+    <<: *docker_sbt
+    steps:
+      - checkout
+      - *cache_restore
+      - *determine_subproject
+      - run:
+          name: Release
+          command: sbt ';project '${PROJECT}' ;set version := "'${VERSION}'"; test; publish'
+      - *cache_save
+
+  test:
+    <<: *docker_sbt
+    steps:
+      - checkout
+      - *cache_restore
+      - run:
+          name: Test all subprojects
+          command: sbt test
+      - *cache_save
+
+  master-build:
+    jobs:
+      - release:
+          filters: {tags: {only: /\S+\/([0-9\.-]+)/}}
+
+  pr-build:
+    jobs:
+      - test:
+          filters: {branches: {ignore: master}}
+

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val common = Seq(
 )
 
 lazy val root = (project in file("."))
-  .settings(common :+ (name := "effect-utilities"))
+  .settings(common :+ (name := "effect-utils"))
   .aggregate(logging)
 
 val logging = project

--- a/build.sbt
+++ b/build.sbt
@@ -17,17 +17,20 @@ val common = Seq(
   ),
   libraryDependencies ++= Seq(
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"),
-    "org.typelevel" %% "cats-effect" % sys.env.getOrElse("CATS_EFFECT_VERSION", "0.10.1"),
+    "org.typelevel" %% "cats-effect" % "0.10.1",
     "org.scalatest" %% "scalatest" % "3.0.5" % "test"
   )
 )
 
 lazy val root = (project in file("."))
-  .settings(common :+ (name := "effect-utils"))
-  .aggregate(logging)
+  .settings(common ++ Seq(name := "effect-utils", publish := nop, publishLocal := nop))
+  .aggregate(logging, currentTime)
 
-val logging = project
-  .settings(common)
+lazy val currentTime = project
+  .settings(common :+ (name := "current-time"))
+
+lazy val logging = project
+  .settings(common :+ (name := "logging"))
   .settings(
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % "1.2.3",

--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,11 @@
-import sbtrelease.ReleaseStateTransformations._
-
-
-resolvers += Resolver.sonatypeRepo("releases")
-
-val bintrayReleaseProcess: Seq[ReleaseStep] = Seq(
-  releaseStepTask(test),
-  inquireVersions,
-  setReleaseVersion,
-  releaseStepTask(publish),
-  commitReleaseVersion,
-  setNextVersion,
-  commitNextVersion
-)
-
 val common = Seq(
   scalaVersion := "2.12.6",
-  organization := "com.ovoenergy",
+  organization := "com.ovoenergy.effect",
   organizationName := "Ovo Energy",
   organizationHomepage := Some(url("http://www.ovoenergy.com")),
   bintrayRepository := "maven",
   bintrayOrganization := Some("ovotech"),
-  releaseCommitMessage := s"Setting version of ${name.value} to ${version.value} [ci skip]",
-  releaseProcess := bintrayReleaseProcess,
+  licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   scalacOptions ++= Seq(
     "-unchecked",
     "-deprecation",
@@ -39,7 +23,8 @@ val common = Seq(
 )
 
 lazy val root = (project in file("."))
-  .settings(common :+ (name := "effect-util"))
+  .settings(common :+ (name := "effect-utilities"))
+  .aggregate(logging)
 
 val logging = project
   .settings(common)

--- a/currentTime/src/main/scala/com/ovoenergy/effect/CurrentTime.scala
+++ b/currentTime/src/main/scala/com/ovoenergy/effect/CurrentTime.scala
@@ -1,0 +1,30 @@
+package com.ovoenergy.effect
+
+import java.time.{ZonedDateTime, Clock => JavaClock}
+
+import cats.effect.Sync
+
+/**
+  * A referentially transparent clock
+  * that returns the time wrapped in an F[_]
+  */
+trait CurrentTime[F[_]] {
+  def now: F[ZonedDateTime]
+}
+
+object CurrentTime {
+
+  // used for the underlying instance
+  private val javaClock = JavaClock.systemUTC
+
+  def apply[F[_]: CurrentTime]: F[ZonedDateTime] =
+    implicitly[CurrentTime[F]].now
+
+  /**
+    * Default instance just passes through to Java
+    * but keeps RT due to the use of the Sync type class
+    */
+  def syncClock[F[_]: Sync]: CurrentTime[F] = new CurrentTime[F] {
+    override def now = Sync[F].delay(ZonedDateTime.now(javaClock))
+  }
+}

--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -1,6 +1,7 @@
 package com.ovoenergy.effect
 
-import cats.FlatMap
+import cats.{Applicative, FlatMap}
+import cats.data.StateT
 import cats.effect.Sync
 import com.typesafe.scalalogging.LazyLogging
 import cats.syntax.flatMap._
@@ -56,6 +57,12 @@ object Logging {
       message.tags.keys.foreach(MDC.remove)
     }
   }
+
+  /**
+    * Lift logging for an F with logging into logging for a StateT[F, S, A]
+    */
+  implicit def stateTLogging[F[_]: Logging: Applicative, S]: Logging[StateT[F, S, ?]] =
+    (what: Log) => StateT.liftF(Logging[F].log(what))
 
   /**
     * Syntax for attaching logging to an effect -

--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -1,10 +1,9 @@
 package com.ovoenergy.effect
 
-import cats.data.StateT
+import cats.FlatMap
 import cats.effect.Sync
-import cats.syntax.flatMap._
-import cats.{Applicative, FlatMap}
 import com.typesafe.scalalogging.LazyLogging
+import cats.syntax.flatMap._
 import org.slf4j.MDC
 
 import scala.language.higherKinds
@@ -57,12 +56,6 @@ object Logging {
       message.tags.keys.foreach(MDC.remove)
     }
   }
-
-  /**
-    * Lift logging for an F with logging into logging for a StateT[F, S, A]
-    */
-  implicit def stateTLogging[F[_]: Logging: Applicative, S]: Logging[StateT[F, S, ?]] =
-    (what: Log) => StateT.liftF(Logging[F].log(what))
 
   /**
     * Syntax for attaching logging to an effect -

--- a/logging/version.sbt
+++ b/logging/version.sbt
@@ -1,1 +1,0 @@
-version := "0.0.1-SNAPSHOT"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")


### PR DESCRIPTION
So this looks a bit different to your average build due to us having (or soon to be having) several subprojects, independently versioned, in the same git repository.

I initially considered using sbt release as per usual but it occurred to me that we don't actually want to auto-increment the version, as to follow [semantic versioning](https://semver.org/) we'll want to alter the versions differently depending on what we've done.

As such this build process uses tags in the format `subproject/major.minor.patch` to identify + release versions of each subproject. The release process then will be the following

- Make delightful changes
- Merge them into master
- Create e.g. `logging/1.1.0` tag either with Github or the cli
- CircleCI will build + release `com.ovoenergy.effect.logging` to bintray
- The app depends on `"com.ovoenergy.effect" %% "logging" % "1.1.0"`

It felt a bit presumptuous to take `com.ovoenergy.logging` and I wanted the artifact name to match the packages you import when using the library, hence me adding `.effect` to the group ID