### PR TITLE
Fix tag resolution not working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
       - run:
           name: Release
           command: |
-          set -e
-          tags=`git describe --tags`
-          sbt ';set version in ThisBuild := "'${tags}'"; test; publish'
+            set -e
+            tags=`git describe --tags`
+            sbt ';set version in ThisBuild := "'${tags}'"; test; publish'
       - *cache_save
 
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,10 @@ jobs:
       - *cache_restore
       - run:
           name: Release
-          command: sbt ';set version in ThisBuild := "'`git describe`'"; test; publish'
+          command: |
+          set -e
+          tags=`git describe --tags`
+          sbt ';set version in ThisBuild := "'${tags}'"; test; publish'
       - *cache_save
 
   test:


### PR DESCRIPTION
`git describe` does not like the unannotated tags created by the Github UI
I also tweaked the build a bit to stop if `git describe --tags` fails for whatever reason so we don't publish strangely versioned artifacts to bintray if things go wrong