### PR TITLE
Allow for logging of exceptions.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,7 +6,6 @@ align {
   openParenDefnSite = false
   tokens.add = [
     "<-",
-    {code = "=", owner = "Param"},
     {code = "=>", owner = "Case"}
   ]
 }

--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -37,8 +37,11 @@ object Logging {
 
   object Error {
     def apply(s: String): Error = Error(Ior.Left(s))
+    def apply(s: String, tags: Tags): Error = Error(Ior.Left(s), tags)
     def apply(t: Throwable): Error = Error(Ior.Right(t))
+    def apply(t: Throwable, tags: Tags): Error = Error(Ior.Right(t), tags)
     def apply(s: String, t: Throwable): Error = Error(Ior.Both(s, t))
+    def apply(s: String, t: Throwable, tags: Tags): Error = Error(Ior.Both(s, t), tags)
   }
 
   // syntax to summon an instance

--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -1,28 +1,28 @@
 package com.ovoenergy.effect
 
-import cats.{Applicative, FlatMap}
-import cats.data.StateT
+import cats.data.{Ior, StateT}
 import cats.effect.Sync
-import com.typesafe.scalalogging.LazyLogging
 import cats.syntax.flatMap._
+import cats.{Applicative, FlatMap}
+import com.typesafe.scalalogging.LazyLogging
 import org.slf4j.MDC
 
 import scala.language.higherKinds
 
 /**
-  * A type class representing the ability to log
-  * within some effect type F
-  */
+ * A type class representing the ability to log
+ * within some effect type F.
+ */
 trait Logging[F[_]] {
   def log(message: Logging.Log): F[Unit]
 }
 
 /**
-  * Our functional code doesn't want to be sprinkled with effectful log statements
-  * and it also doesn't want to be tied to the IO monad, so we define a type class for some F
-  * which permits logging, returning an unmodified value wrapped in a (presumably modified) F
-  * In production code we can use SLF4J and IO, in tests we can use a Writer[List[Log]]
-  */
+ * Our functional code doesn't want to be sprinkled with effectful log statements
+ * and it also doesn't want to be tied to the IO monad, so we define a type class for some F
+ * which permits logging, returning an unmodified value wrapped in a (presumably modified) F.
+ * In production code we can use SLF4J and IO, in tests we can use a `Writer[List[Log]]`.
+ */
 object Logging {
 
   type Tags = Map[String, String]
@@ -31,17 +31,23 @@ object Logging {
     def tags: Tags
   }
 
-  case class Debug(of: String, tags: Tags = Map.empty) extends Log
-  case class Info(of: String, tags: Tags  = Map.empty) extends Log
-  case class Error(of: String, tags: Tags = Map.empty) extends Log
+  case class Debug(of: String, tags: Tags                 = Map.empty) extends Log
+  case class Info(of: String, tags: Tags                  = Map.empty) extends Log
+  case class Error(of: Ior[String, Throwable], tags: Tags = Map.empty) extends Log
+
+  object Error {
+    def apply(s: String): Error = Error(Ior.Left(s))
+    def apply(t: Throwable): Error = Error(Ior.Right(t))
+    def apply(s: String, t: Throwable): Error = Error(Ior.Both(s, t))
+  }
 
   // syntax to summon an instance
   def apply[F[_]: Logging]: Logging[F] = implicitly
 
   /**
-    * An instance of logging for a Sync[F] which just wraps the call
-    * to the underlying logger
-    */
+   * An instance of logging for a Sync[F] which just wraps the call
+   * to the underlying logger
+   */
   //noinspection ConvertExpressionToSAM
   def syncLogging[F[_]: Sync]: Logging[F] = new Logging[F] with LazyLogging {
     def log(message: Log): F[Unit] = Sync[F].delay {
@@ -50,25 +56,32 @@ object Logging {
           MDC.put(k, v)
       }
       message match {
-        case Debug(content, _) => logger.debug(content)
-        case Info(content, _)  => logger.info(content)
-        case Error(content, _) => logger.error(content)
+        case Debug(of, _) =>
+          logger.debug(of)
+        case Info(of, _) =>
+          logger.info(of)
+        case Error(of, _) =>
+          of.fold(
+            logger.error(_),
+            e => logger.error(e.getMessage, e),
+            (s, t) => logger.error(s, t)
+          )
       }
       message.tags.keys.foreach(MDC.remove)
     }
   }
 
   /**
-    * Lift logging for an F with logging into logging for a StateT[F, S, A]
-    */
+   * Lift logging for an F with logging into logging for a `StateT[F, S, A]`.
+   */
   implicit def stateTLogging[F[_]: Logging: Applicative, S]: Logging[StateT[F, S, ?]] =
     (what: Log) => StateT.liftF(Logging[F].log(what))
 
   /**
-    * Syntax for attaching logging to an effect -
-    * the logging will run _before_ the effect is evaluated, so even if say your IO fails
-    * you'll get logs
-    */
+   * Syntax for attaching logging to an effect -
+   * the logging will run _before_ the effect is evaluated,
+   * so even if say your IO fails you'll get logs.
+   */
   implicit class LogSyntax[F[_]: Logging: FlatMap, A](i: F[A]) {
     def log(l: Log): F[A] = Logging[F].log(l) >> i
   }

--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -31,8 +31,8 @@ object Logging {
     def tags: Tags
   }
 
-  case class Debug(of: String, tags: Tags                 = Map.empty) extends Log
-  case class Info(of: String, tags: Tags                  = Map.empty) extends Log
+  case class Debug(of: String, tags: Tags = Map.empty) extends Log
+  case class Info(of: String, tags: Tags = Map.empty) extends Log
   case class Error(of: Ior[String, Throwable], tags: Tags = Map.empty) extends Log
 
   object Error {

--- a/logging/src/test/scala/com/ovoenergy/effect/LoggingTest.scala
+++ b/logging/src/test/scala/com/ovoenergy/effect/LoggingTest.scala
@@ -4,7 +4,7 @@ import cats.data.WriterT
 import cats.effect.IO
 import cats.instances.list._
 import cats.syntax.flatMap._
-import com.ovoenergy.effect.Logging.{Debug, Info, Log, _}
+import com.ovoenergy.effect.Logging.{Debug, Error, Info, Log, _}
 import org.scalatest.{Matchers, WordSpec}
 
 class LoggingTest extends WordSpec with Matchers {
@@ -14,12 +14,28 @@ class LoggingTest extends WordSpec with Matchers {
 
   "Logging syntax" should {
 
-    "Log before running the actual effect" in {
+    "log before running the actual effect" in {
       val message = Debug("Testing logging")
       val toLog: LogWriter[Unit] = WriterT.liftF(IO.unit)
       val expected = List(message, Info("boo"))
       val events = (toLog >> Logging[LogWriter].log(Info("boo"))).log(message)
+
       events.written.unsafeRunSync shouldEqual expected
+    }
+
+    "log exceptions" in {
+      val errors = List(
+        Error("err"),
+        Error(new RuntimeException("ex")),
+        Error("another", new RuntimeException("ex2"))
+      )
+
+      val toLog: LogWriter[Unit] = WriterT.liftF(IO.unit)
+      val events = errors.foldLeft(toLog) {
+        case (log, err) => log.log(err)
+      }
+
+      events.written.unsafeRunSync shouldEqual errors.reverse
     }
   }
 }


### PR DESCRIPTION
Allows the `Logging.Error` case class to take a `String`, a `Throwable` or both.