### PR TITLE
Add the trace token to the MDC when logging

### DIFF
--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -109,7 +109,7 @@ object Logging {
         }
 
       def mdc: Traced[F, Tags] =
-        token.inspect(_.mdc)
+        token.transform { case (ctx, token) => (ctx, ctx.mdc.updated("traceToken", token.value)) }
 
       def putToken(traceToken: TraceToken): Traced[F, Unit] =
         StateT.modify(_.copy(token = Some(traceToken)))


### PR DESCRIPTION
I missed this initially, but the trace token should be added to the `MDC` automatically for logging purposes