### PR TITLE
Split tracing and logging

### DIFF
--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -77,16 +77,9 @@ object Logging {
   }
 
   /**
-   * More syntax, but standalone functions this time
+   * More syntax, but a standalone function this time
    * to cut down on the Logging[F].log(Info(...)) boilerplate
    */
-  def info[F[_] : Logging](what: String)(tags: Tags = Map.empty): F[Unit] =
-    Logging[F].log(Info(what), tags)
-
-  def debug[F[_] : Logging](what: String)(tags: Tags = Map.empty): F[Unit] =
-    Logging[F].log(Debug(what), tags)
-
-  def error[F[_] : Logging](what: Throwable)(tags: Tags = Map.empty): F[Unit] =
-    Logging[F].log(Error(Ior.Right(what)), tags)
-
+  def log[F[_] : Logging](what: Log, tags: Tags = Map.empty): F[Unit] =
+    Logging[F].log(what, tags)
 }

--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -1,13 +1,11 @@
 package com.ovoenergy.effect
 
-import java.util.UUID
-
-import cats.data.{Ior, StateT}
-import cats.effect.{IO, Sync}
+import cats.FlatMap
+import cats.data.Ior
+import cats.effect.Sync
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import cats.{Applicative, FlatMap, Monad, Monoid, ~>}
-import com.ovoenergy.effect.Logging.{Tags, TraceToken}
+import com.ovoenergy.effect.Logging.Tags
 import org.slf4j.{LoggerFactory, MDC}
 
 import scala.language.higherKinds
@@ -18,38 +16,6 @@ import scala.language.higherKinds
  * passed through using a StateT or similar
  */
 trait Logging[F[_]] {
-
-  /**
-    * Reset the internal state of the logging
-    */
-  def reset: F[Unit]
-
-  /**
-    * Get the current trace token,
-    * or generate a new one if there is none
-    */
-  def token: F[TraceToken]
-
-  /**
-    * Set the current trace token
-    */
-  def putToken(traceToken: TraceToken): F[Unit]
-
-  /**
-    * Get the current MDC info
-    */
-  def mdc: F[Map[String, String]]
-
-  /**
-    * Add key/value pairs to the MDC
-    * that will become available in future calls to mdc
-    */
-  def putMdc(values: (String, String)*): F[Unit]
-
-  /**
-    * Log something,
-    * joining on MDC + trace token information
-    */
   def log(message: Logging.Log, tags: Tags = Map.empty): F[Unit]
 }
 
@@ -62,8 +28,6 @@ trait Logging[F[_]] {
 object Logging {
 
   type Tags = Map[String, String]
-  type Traced[F[_], A] = StateT[F, TraceContext, A]
-  type TraceIO[A] = Traced[IO, A]
 
   sealed trait Log
   case class Debug(of: String) extends Log
@@ -76,100 +40,31 @@ object Logging {
     def apply(s: String, t: Throwable): Error = Error(Ior.Both(s, t))
   }
 
-  case class TraceToken(value: String) extends AnyVal
-  case class TraceContext(token: Option[TraceToken], mdc: Map[String, String])
-
-  object TraceContext {
-    implicit val monoid: Monoid[TraceContext] = new Monoid[TraceContext] {
-      def combine(x: TraceContext, y: TraceContext) = TraceContext(y.token.orElse(x.token), x.mdc ++ y.mdc)
-      def empty = TraceContext(None, Map.empty)
-    }
-  }
 
   // syntax to summon an instance
   def apply[F[_]: Logging]: Logging[F] = implicitly
 
   /**
-   * Given some F[_], produce a Logging instance for a Traced[F[_], ?], which
-   * boils down to a StateT containing MDC info + a trace token
-   */
-  def tracedInstance[F[_]: Monad](
-    newToken: F[TraceToken],
-    execLog: (Log, Tags) => F[Unit]
-  ): Logging[Traced[F, ?]] =
-    new Logging[Traced[F, ?]] {
-
-      def reset: StateT[F, TraceContext, Unit] =
-        StateT.modify(_ => TraceContext.monoid.empty)
-
-      def token: StateT[F, TraceContext, TraceToken] =
-        StateT { trace =>
-          val token: F[TraceToken] = trace.token.fold(newToken)(Applicative[F].pure)
-          token.map(t => trace.copy(token = Some(t)) -> t)
-        }
-
-      def mdc: Traced[F, Tags] =
-        token.transform { case (ctx, token) => (ctx, ctx.mdc.updated("traceToken", token.value)) }
-
-      def putToken(traceToken: TraceToken): Traced[F, Unit] =
-        StateT.modify(_.copy(token = Some(traceToken)))
-
-      def putMdc(values: (String, String)*): Traced[F, Unit] =
-        StateT.modify(ctx => ctx.copy(mdc = ctx.mdc ++ values.toMap))
-
-      def log(message: Log, tags: Tags): Traced[F, Unit] =
-        mdc.flatMapF(mdc => execLog(message, mdc ++ tags))
-   }
-
-  /**
-    * Turn a Traced[F, A] into an F[A]
-    * by running it with an initial empty trace context
-    */
-  def dropTracing[F[_]: Monad]: Traced[F, ?] ~> F =
-    new (Traced[F, ?] ~> F) { def apply[A](t: Traced[F, A]): F[A] = t.runEmptyA }
-
-  /**
-    * Create an instance of logging with no tracing that will ignore any tracing calls
-    * This is only intended for unit tests where you're simply not interested in the tracing
-    */
-  def untracedInstance[F[_]](
-    newToken: F[TraceToken],
-    execLog: Log => F[Unit]
-  )(implicit F: Applicative[F]): Logging[F] =
-    new Logging[F] {
-      def reset: F[Unit] = F.unit
-      def token: F[TraceToken] = newToken
-      def putToken(traceToken: TraceToken): F[Unit] = F.unit
-      def mdc: F[Map[String, String]] = F.pure(Map.empty)
-      def putMdc(values: (String, String)*): F[Unit] = F.unit
-      def log(message: Log, tags: Tags): F[Unit] = execLog(message)
-    }
-
-  /**
     * An instance of logging using SLF4J
     * requires your F[_] to be a sync
     */
-  def slf4jLogging[F[_] : Sync]: F[Logging[Traced[F, ?]]] =
+  def slf4jLogging[F[_] : Sync]: F[Logging[F]] =
     Sync[F].delay(LoggerFactory.getLogger("logging")).map { logger =>
-      tracedInstance[F](
-        newToken = Sync[F].delay(TraceToken(UUID.randomUUID.toString)),
-        execLog = { (log, tags) =>
-          Sync[F].delay {
-            val context = tags.map { case (k, v) => MDC.putCloseable(k, v) }
-            try {
-              log match {
-                case Debug(what)           => logger.debug(what)
-                case Info(what)            => logger.info(what)
-                case Error(Ior.Left(a))    => logger.error(a)
-                case Error(Ior.Right(a))   => logger.error(a.getMessage, a)
-                case Error(Ior.Both(a, t)) => logger.error(a, t)
-              }
-            } finally {
-              context.foreach(_.close)
+      (log, tags) =>
+        Sync[F].delay {
+          val context = tags.map { case (k, v) => MDC.putCloseable(k, v) }
+          try {
+            log match {
+              case Debug(what)           => logger.debug(what)
+              case Info(what)            => logger.info(what)
+              case Error(Ior.Left(a))    => logger.error(a)
+              case Error(Ior.Right(a))   => logger.error(a.getMessage, a)
+              case Error(Ior.Both(a, t)) => logger.error(a, t)
             }
+          } finally {
+            context.foreach(_.close)
           }
         }
-      )
     }
 
   /**
@@ -185,12 +80,13 @@ object Logging {
    * More syntax, but standalone functions this time
    * to cut down on the Logging[F].log(Info(...)) boilerplate
    */
-  def info[F[_] : Logging](what: String, tags: Tags = Map.empty): F[Unit] =
+  def info[F[_] : Logging](what: String)(tags: Tags = Map.empty): F[Unit] =
     Logging[F].log(Info(what), tags)
 
-  def debug[F[_] : Logging](what: String, tags: Tags = Map.empty): F[Unit] =
+  def debug[F[_] : Logging](what: String)(tags: Tags = Map.empty): F[Unit] =
     Logging[F].log(Debug(what), tags)
 
-  def error[F[_] : Logging](what: Throwable, tags: Tags = Map.empty): F[Unit] =
+  def error[F[_] : Logging](what: Throwable)(tags: Tags = Map.empty): F[Unit] =
     Logging[F].log(Error(Ior.Right(what)), tags)
+
 }

--- a/logging/src/main/scala/com/ovoenergy/effect/TraceLogging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/TraceLogging.scala
@@ -1,0 +1,15 @@
+package com.ovoenergy.effect
+import cats.FlatMap
+import cats.syntax.flatMap._
+import com.ovoenergy.effect.Logging.{Log, Tags}
+import com.ovoenergy.effect.Tracing.mdc
+
+/**
+  * Syntax for automatically pulling tracing information into logs
+  * when your effect type supports both logging and tracing
+  */
+object TraceLogging {
+
+  def mdcLog[F[_] : Logging: Tracing: FlatMap](what: Log, tags: Tags = Map.empty): F[Unit] =
+    mdc.flatMap(mdc => Logging[F].log(what, mdc  ++ tags))
+}

--- a/logging/src/main/scala/com/ovoenergy/effect/Tracing.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Tracing.scala
@@ -1,0 +1,88 @@
+package com.ovoenergy.effect
+import java.util.UUID
+
+import cats.data.StateT
+import cats.effect.{IO, Sync}
+import cats.{FlatMap, Functor, Id, Monad, Monoid, MonoidK, ~>}
+import com.ovoenergy.effect.Tracing.TraceContext
+import cats.syntax.functor._
+import cats.instances.option._
+import cats.syntax.flatMap._
+import com.ovoenergy.effect.Logging.Tags
+
+trait Tracing[F[_]] {
+  def reset: F[Unit]
+  def put(traceToken: TraceContext[Id]): F[Unit]
+  def get: F[TraceContext[Id]]
+}
+
+object Tracing {
+
+  type Traced[F[_], A] = StateT[F, TraceContext[Option], A]
+  type TraceIO[A] = Traced[IO, A]
+
+  case class TraceToken(value: String) extends AnyVal
+  case class TraceContext[G[_]](token: G[TraceToken], mdc: Map[String, String])
+
+  def apply[F[_] : Tracing]: Tracing[F] = implicitly
+
+  object TraceContext {
+    implicit def monoid[G[_] : MonoidK]: Monoid[TraceContext[G]] =
+      new Monoid[TraceContext[G]] {
+        def empty =
+          TraceContext(MonoidK[G].empty, Map.empty)
+        def combine(x: TraceContext[G], y: TraceContext[G]) =
+          TraceContext(MonoidK[G].combineK(x.token, y.token), x.mdc ++ y.mdc)
+      }
+  }
+
+  /**
+   * Given some F[_], produce a Tracing instance for a Traced[F[_], ?], which
+   * boils down to a StateT containing MDC info + a trace token
+   */
+  implicit def instance[F[_]: Sync]: Tracing[Traced[F, ?]] =
+    new Tracing[Traced[F, ?]] {
+
+      def reset: Traced[F, Unit] =
+        StateT.modify(_ => TraceContext[Option](None, Map.empty))
+
+      def get: Traced[F, TraceContext[Id]] =
+        StateT {
+          case TraceContext(None, mdc) =>
+            val newToken = Sync[F].delay(TraceToken(UUID.randomUUID.toString))
+            newToken.map(t => TraceContext(Option(t), mdc) -> TraceContext[Id](t, mdc))
+          case s @ TraceContext(Some(token), mdc) =>
+            Monad[F].pure(s -> TraceContext[Id](token, mdc))
+        }
+
+      def put(ctx: TraceContext[Id]): Traced[F, Unit] =
+        StateT.set(ctx.copy[Option](token = Some(ctx.token)))
+    }
+
+  /**
+    * Turn a Traced[F, A] into an F[A]
+    * by running it with an initial empty trace context
+    */
+  def dropTracing[F[_]: Monad]: Traced[F, ?] ~> F =
+    new (Traced[F, ?] ~> F) { def apply[A](t: Traced[F, A]): F[A] = t.runEmptyA }
+
+  /**
+    * The following functions are syntax sugar for various operations on the trace context
+    * most notably trace, which takes a function requiring tags and provides them..
+    * useful for logging
+    */
+  def token[F[_] : Tracing : Functor]: F[TraceToken] =
+    Tracing[F].get.map(_.token)
+
+  def putToken[F[_] : Tracing : Monad](token: TraceToken): F[Unit] =
+    Tracing[F].get.flatMap(c => Tracing[F].put(c.copy[Id](token = token)))
+
+  def mdc[F[_] : Tracing: Functor]: F[Tags] =
+    Tracing[F].get.map(c => c.mdc.updated("traceToken", c.token.value))
+
+  def trace[F[_]: FlatMap](fn: Tags => F[Unit])(implicit t: Tracing[Traced[F, ?]]): Traced[F, Unit] =
+    mdc[Traced[F, ?]].flatMapF(fn)
+
+  def putMdc[F[_] : Tracing : Monad](tags: (String, String)*): F[Unit] =
+    Tracing[F].get.flatMap(c => Tracing[F].put(c.copy(mdc = c.mdc ++ tags.toMap)))
+}

--- a/logging/src/main/scala/com/ovoenergy/effect/Tracing.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Tracing.scala
@@ -10,6 +10,11 @@ import cats.instances.option._
 import cats.syntax.flatMap._
 import com.ovoenergy.effect.Logging.Tags
 
+/**
+  * This type class abstracts away from a StateT essentially,
+  * providing functionality to get and set MDC info & trace tokens
+  * within a given effect type
+  */
 trait Tracing[F[_]] {
   def reset: F[Unit]
   def put(traceToken: TraceContext[Id]): F[Unit]

--- a/logging/src/test/scala/com/ovoenergy/effect/TracingTest.scala
+++ b/logging/src/test/scala/com/ovoenergy/effect/TracingTest.scala
@@ -1,0 +1,32 @@
+package com.ovoenergy.effect
+
+import cats.effect.IO
+import cats.syntax.flatMap._
+import com.ovoenergy.effect.Tracing.{TraceIO, TraceToken, _}
+import org.scalatest.{Inspectors, Matchers, WordSpec}
+
+class TracingTest extends WordSpec with Matchers with Inspectors {
+
+  val token = TraceToken("foo")
+  implicit val trace: Tracing[TraceIO] = Tracing.instance[IO]
+  def run[A](t: TraceIO[A]): A = dropTracing[IO].apply[A](t).unsafeRunSync
+
+  "Tracing" should {
+
+    "Store MDC info" in {
+      run(putMdc("foo" -> "bar") >> mdc).get("foo") shouldBe Some("bar")
+    }
+
+    "Create a trace token if one is not set then use the same one thereafter" in {
+        val result = run(
+          for {
+            token1 <- Tracing.token
+            token2 <- Tracing.token
+          } yield List(token1, token2)
+        )
+
+      result.head.value.nonEmpty shouldBe true
+      result.head shouldBe result.tail.head
+    }
+  }
+}


### PR DESCRIPTION
Okay so you may remember how originally in our apps `Tracing` and `Logging` were separate but then I merged them in this library...

Turns out that was a bad idea - we can't use `StateT` for tracing within FS2 streams but we still want to be able to log things in them, getting the tags to include from elsewhere.

With the merged type classes there was no way to represent that I could log within some effect but not see / modify tracing information, so this PR splits them into two and adds a third `TraceLogging` object with a tiny bit of syntax to tie them together when your `F[_]` does support both tracing and logging

This does make tracing / logging a bit more painful than it used to be (lots of `F[_]: Tracing: Logging`) but you'll see in future PRs elsewhere it means we can pass around tracing info in other ways as the situation requires

I also adopted a simpler approach to type classes in that rather than the `Tracing` type class supporting `putMdc`,` putTraceToken` etc it just has functions to get & write to the entire trace context, and all the other operations are derived from those in plain old functions in the companion object