### PR TITLE
Datadog metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val common = Seq(
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.12.7",
   organization := "com.ovoenergy.effect",
   organizationName := "Ovo Energy",
   organizationHomepage := Some(url("http://www.ovoenergy.com")),
@@ -18,15 +18,16 @@ val common = Seq(
   ),
   libraryDependencies ++= Seq(
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.10"),
-    "org.typelevel" %% "cats-effect" % "1.2.0",
-    "org.scalatest" %% "scalatest" % "3.0.7" % "test",
+    "org.typelevel" %% "cats-core" % "1.4.0",
+    "org.typelevel" %% "cats-effect" % "1.3.1",
+    "org.scalatest" %% "scalatest" % "3.0.8" % "test",
     "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
   )
 )
 
 lazy val root = (project in file("."))
   .settings(common ++ Seq(name := "effect-utils", publish := nop, publishLocal := nop))
-  .aggregate(logging, kamonMetrics)
+  .aggregate(logging, metricsCommon, kamonMetrics, datadogMetrics)
 
 lazy val logging = project
   .settings(common :+ (name := "logging"))
@@ -37,11 +38,27 @@ lazy val logging = project
     )
   )
 
+lazy val metricsCommon = project
+  .in(file("metrics-common")).settings(common :+ (name := "metrics-common"))
+
 lazy val kamonMetrics = project
-  .in(file("kamon-metrics"))
+  .in(file("metrics-kamon"))
   .settings(common :+ (name := "kamon-metrics"))
+  .dependsOn(metricsCommon)
   .settings(
     libraryDependencies ++= Seq(
       "io.kamon" %% "kamon-core" % "1.1.0"
+    )
+  )
+
+val fs2Version = "1.0.5"
+lazy val datadogMetrics = project
+  .in(file("metrics-datadog"))
+  .settings(common :+ (name := "datadog-metrics"))
+  .dependsOn(metricsCommon)
+  .settings(
+    libraryDependencies ++= Seq(
+      "co.fs2" %% "fs2-core" % fs2Version,
+      "co.fs2" %% "fs2-io" % fs2Version,
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val common = Seq(
-  scalaVersion := "2.12.7",
+  scalaVersion := "2.12.9",
   organization := "com.ovoenergy.effect",
   organizationName := "Ovo Energy",
   organizationHomepage := Some(url("http://www.ovoenergy.com")),
@@ -19,7 +19,7 @@ val common = Seq(
   libraryDependencies ++= Seq(
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.10"),
     "org.typelevel" %% "cats-core" % "1.4.0",
-    "org.typelevel" %% "cats-effect" % "1.3.1",
+    "org.typelevel" %% "cats-effect" % "1.4.0",
     "org.scalatest" %% "scalatest" % "3.0.8" % "test",
     "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
   )

--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -5,7 +5,7 @@ import cats.data.Ior
 import cats.effect.Sync
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import com.ovoenergy.effect.Logging.Tags
+import Logging.Tags
 import org.slf4j.{LoggerFactory, MDC}
 
 import scala.language.higherKinds

--- a/logging/src/main/scala/com/ovoenergy/effect/TraceLogging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/TraceLogging.scala
@@ -1,8 +1,10 @@
 package com.ovoenergy.effect
+
 import cats.FlatMap
 import cats.syntax.flatMap._
 import com.ovoenergy.effect.Logging.{Log, Tags}
 import com.ovoenergy.effect.Tracing.mdc
+import Logging.Log
 
 /**
   * Syntax for automatically pulling tracing information into logs

--- a/logging/src/main/scala/com/ovoenergy/effect/Tracing.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Tracing.scala
@@ -1,14 +1,15 @@
 package com.ovoenergy.effect
+
 import java.util.UUID
 
 import cats.data.StateT
 import cats.effect.{IO, Sync}
 import cats.{FlatMap, Functor, Id, Monad, Monoid, MonoidK, ~>}
-import com.ovoenergy.effect.Tracing.TraceContext
+import Tracing.TraceContext
 import cats.syntax.functor._
 import cats.instances.option._
 import cats.syntax.flatMap._
-import com.ovoenergy.effect.Logging.Tags
+import Logging.Tags
 
 /**
   * This type class abstracts away from a StateT essentially,

--- a/logging/src/test/scala/com/ovoenergy/effect/LoggingTest.scala
+++ b/logging/src/test/scala/com/ovoenergy/effect/LoggingTest.scala
@@ -5,7 +5,7 @@ import cats.data.WriterT
 import cats.effect.IO
 import cats.instances.list._
 import cats.syntax.flatMap._
-import com.ovoenergy.effect.Logging._
+import Logging._
 import org.scalatest.{Inspectors, Matchers, WordSpec}
 
 class LoggingTest extends WordSpec with Matchers with Inspectors {

--- a/logging/src/test/scala/com/ovoenergy/effect/TracingTest.scala
+++ b/logging/src/test/scala/com/ovoenergy/effect/TracingTest.scala
@@ -2,7 +2,7 @@ package com.ovoenergy.effect
 
 import cats.effect.IO
 import cats.syntax.flatMap._
-import com.ovoenergy.effect.Tracing.{TraceIO, TraceToken, _}
+import Tracing.{TraceIO, TraceToken, _}
 import org.scalatest.{Inspectors, Matchers, WordSpec}
 
 class TracingTest extends WordSpec with Matchers with Inspectors {

--- a/metrics-common/src/main/scala/com/ovoenergy/effect/Metrics.scala
+++ b/metrics-common/src/main/scala/com/ovoenergy/effect/Metrics.scala
@@ -1,0 +1,17 @@
+package com.ovoenergy.effect
+
+import com.ovoenergy.effect.Metrics.Metric
+
+/**
+ * A type class representing the ability to push metrics
+ * within some effect type F
+ */
+trait Metrics[F[_]] {
+  def counter(metric: Metric): F[Long => F[Unit]]
+  def histogram(metric: Metric): F[Long => F[Unit]]
+}
+
+object Metrics {
+  case class Metric(name: String, tags: Map[String, String])
+  def apply[F[_]: Metrics]: Metrics[F] = implicitly
+}

--- a/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
+++ b/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
@@ -24,7 +24,7 @@ object Datadog {
    * and not contain any chars other than letters, numbers and underscores
    */
   private[effect] def filterChars(s: String): String =
-    s.dropWhile(!_.isLetter).replaceAll("[^A-Za-z0-9]+", "_" )
+    s.dropWhile(!_.isLetter).replaceAll("[^A-Za-z0-9\\.]+", "_" )
 
   private def serialiseTags(t: Map[String, String]): String = {
     val tagString = t.toList.map { case (k, v) => s"${filterChars(k)}:${filterChars(v)}"}.mkString(",")

--- a/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
+++ b/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
@@ -1,0 +1,66 @@
+package com.ovoenergy.effect
+
+import java.net.InetSocketAddress
+
+import cats.effect._
+import cats.instances.option._
+import com.ovoenergy.effect.Metrics.Metric
+import fs2.Chunk.array
+import fs2.io.udp._
+
+object Datadog {
+
+  case class Config(
+    agentHost: InetSocketAddress,
+    metricPrefix: Option[String],
+    globalTags: Map[String, String]
+  )
+
+  private implicit val group: AsynchronousSocketGroup =
+    AsynchronousSocketGroup.apply
+
+  /**
+   * Datadog enforces all metrics must start with a letter
+   * and not contain any chars other than letters, numbers and underscores
+   */
+  private[effect] def filterChars(s: String): String =
+    s.dropWhile(!_.isLetter).replaceAll("[^A-Za-z0-9]+", "_" )
+
+  private def serialiseTags(t: Map[String, String]): String = {
+    val tagString = t.toList.map { case (k, v) => s"${filterChars(k)}:${filterChars(v)}"}.mkString(",")
+    if (tagString.nonEmpty) s"|#$tagString" else ""
+  }
+
+  private[effect] def serialiseCounter(m: Metric, value: Long): String =
+    s"${filterChars(m.name)}:$value|c${serialiseTags(m.tags)}"
+
+  private[effect] def serialiseHistogram(m: Metric, value: Long): String =
+    s"${filterChars(m.name)}:$value|h|@1.0${serialiseTags(m.tags)}"
+
+  private[effect] def applyConfig(m: Metric, config: Config): Metric =
+    Metric((config.metricPrefix.toList :+ m.name).mkString("."), config.globalTags ++ m.tags)
+
+  /**
+   * Take care of the gymnastics required to send a string to the `to` destination through
+   * a socket in F before turning the resulting unit into a `G[Unit]` so our types line up
+   */
+  private def send[F[_]: Effect, G[_]: Async](skt: Socket[F], to: InetSocketAddress, what: String): G[Unit] =
+    Async[G].liftIO(Effect[F].toIO(skt.write(Packet(to, array(what.getBytes)))))
+
+  /**
+   * Create an instance of Metrics that uses a UDP socket to communicate with Datadog.
+   */
+  def apply[F[_]: ContextShift, G[_]](config: Config)(
+    implicit
+    G: Async[G],
+    F: ConcurrentEffect[F]
+  ): Resource[F, Metrics[G]] =
+    Socket[F]().map { sock =>
+      new Metrics[G] {
+        def counter(m: Metric): G[Long => G[Unit]] =
+          G.pure(v => send[F, G](sock, config.agentHost, serialiseCounter(applyConfig(m, config), v)))
+        def histogram(m: Metric): G[Long => G[Unit]] =
+          G.pure(v => send[F, G](sock, config.agentHost, serialiseHistogram(applyConfig(m, config), v)))
+      }
+    }
+}

--- a/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
+++ b/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
@@ -1,0 +1,82 @@
+package com.ovoenergy.effect
+
+import java.net.InetSocketAddress
+
+import com.ovoenergy.effect.Datadog._
+import com.ovoenergy.effect.Metrics.Metric
+import org.scalacheck.Gen.mapOf
+import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.scalatest.{Matchers, WordSpec}
+import org.scalatestplus.scalacheck.Checkers
+
+class DatadogTest extends WordSpec with Matchers with Checkers {
+
+  val string: Gen[String] =
+    Arbitrary.arbString.arbitrary
+
+  val stringTags: Gen[Map[String, String]] =
+    mapOf(Gen.zip(string, string))
+
+  implicit val metric: Gen[Metric] =
+    for {
+      name <- string
+      tags <- stringTags
+    } yield Metric(name, tags)
+
+  "Datadog serialisation" should {
+
+    "Never submit double underscores to datadog" in {
+      check(
+        Prop.forAll(metric) { str =>
+          !serialiseCounter(str, 1).matches(".*?__.*?") &&
+          !serialiseHistogram(str, 1).matches(".*?__.*?")
+        }
+      )
+    }
+
+    "Generate correct counters and histograms with no tags" in {
+      check(
+        Prop.forAll(Arbitrary.arbLong.arbitrary) { l =>
+          serialiseCounter(Metric("foo", Map.empty), l) == s"foo:$l|c" &&
+          serialiseHistogram(Metric("foo", Map.empty), l) == s"foo:$l|h|@1.0"
+        }
+      )
+    }
+
+    "Generate correct counters & histograms with tags" in {
+      check(
+        Prop.forAll(stringTags.suchThat(_.nonEmpty)) { tags =>
+          val exp = tags.map { case (k, v) => s"${filterChars(k)}:${filterChars(v)}"}.mkString(",")
+          serialiseHistogram(Metric("foo", tags), 1) == s"foo:1|h|@1.0|#$exp" &&
+          serialiseCounter(Metric("foo", tags), 1) == s"foo:1|c|#$exp"
+        }
+      )
+    }
+  }
+
+  "Configuration" should {
+
+    "Not overwrite existing tags" in {
+      val config = Config(new InetSocketAddress(0), None, Map("bar" -> "boz"))
+      applyConfig(Metric("foo", Map("bar" -> "baz")), config).tags shouldBe Map("bar" -> "baz")
+    }
+
+    "Add new tags where they're not specified" in {
+      check(
+        Prop.forAll(stringTags) { ts =>
+          val config = Config(new InetSocketAddress(0), None, ts)
+          applyConfig(Metric("foo", Map.empty), config).tags == ts
+        }
+      )
+    }
+
+    "Separate the global prefix from the metric name with a dot" in {
+      check(
+        Prop.forAll(string) { prefix =>
+          val config = Config(new InetSocketAddress(0), Some(prefix), Map("bar" -> "boz"))
+          applyConfig(Metric("foo", Map.empty), config).name == s"$prefix.foo"
+        }
+      )
+    }
+  }
+}

--- a/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
+++ b/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
@@ -27,9 +27,16 @@ class DatadogTest extends WordSpec with Matchers with Checkers {
 
     "Never submit double underscores to datadog" in {
       check(
-        Prop.forAll(metric) { str =>
-          !serialiseCounter(str, 1).matches(".*?__.*?") &&
-          !serialiseHistogram(str, 1).matches(".*?__.*?")
+        Prop.forAll(string) { str =>
+          !filterChars(str).matches(".*?__.*?")
+        }
+      )
+    }
+
+    "Allow through dots" in {
+      check(
+        Prop.forAll(Gen.alphaNumStr, Gen.alphaNumStr) { case (pref, suf) =>
+          filterChars(s"$pref.$suf") == s"$pref.$suf".dropWhile(!_.isLetter)
         }
       )
     }

--- a/metrics-kamon/src/main/scala/com/ovoenergy/effect/Kamon.scala
+++ b/metrics-kamon/src/main/scala/com/ovoenergy/effect/Kamon.scala
@@ -3,36 +3,23 @@ package com.ovoenergy.effect
 import cats.effect.Sync
 import cats.syntax.functor._
 import com.ovoenergy.effect.Metrics.Metric
-import kamon.Kamon
+import kamon.{Kamon => K}
 
 import scala.language.higherKinds
 
-/**
- * A type class representing the ability to push metrics
- * within some effect type F
- */
-trait Metrics[F[_]] {
-  def counter(metric: Metric): F[Long => F[Unit]]
-  def histogram(metric: Metric): F[Long => F[Unit]]
-}
-
-object Metrics {
-
-  case class Metric(name: String, tags: Map[String, String])
-
-  def apply[F[_]: Metrics]: Metrics[F] = implicitly
-
+object Kamon {
   /**
    * An instance of metrics for a Sync[F] which wraps the underlying calls
    */
   def syncKamonMetrics[F[_]: Sync]: Metrics[F] = new Metrics[F] {
+
     def counter(metric: Metric): F[Long => F[Unit]] =
-      Sync[F].delay(Kamon.counter(metric.name).refine(metric.tags)).map(
+      Sync[F].delay(K.counter(metric.name).refine(metric.tags)).map(
         counter => times => Sync[F].delay(counter.increment(times))
       )
 
     def histogram(metric: Metric): F[Long => F[Unit]] =
-      Sync[F].delay(Kamon.histogram(metric.name).refine(metric.tags)).map(
+      Sync[F].delay(K.histogram(metric.name).refine(metric.tags)).map(
         histogram => duration => Sync[F].delay(histogram.record(duration))
       )
   }

--- a/metrics-kamon/src/test/scala/com/ovoenergy/effect/MetricsTest.scala
+++ b/metrics-kamon/src/test/scala/com/ovoenergy/effect/MetricsTest.scala
@@ -4,7 +4,7 @@ import cats.Id
 import cats.data.WriterT
 import cats.instances.list._
 import cats.instances.map._
-import com.ovoenergy.effect.Metrics.Metric
+import Metrics.Metric
 import org.scalatest.{Matchers, WordSpec}
 
 class MetricsTest extends WordSpec with Matchers {
@@ -13,7 +13,7 @@ class MetricsTest extends WordSpec with Matchers {
 
     type LogWriter[A] = WriterT[Id, Map[Metric, List[Long]], A]
 
-    implicit val testMetrics = new Metrics[LogWriter] {
+    implicit val testMetrics: Metrics[LogWriter] = new Metrics[LogWriter] {
       override def counter(metric: Metric): LogWriter[Long => LogWriter[Unit]] = {
         val writer: Long => LogWriter[Unit] = value => WriterT.tell(Map(metric -> List(value)))
 


### PR DESCRIPTION
This PR

- Splits the `Metrics` trait out into its own jar so we can use it across implementations
- Adds a minimal datadog implementation that sends metrics over UDP to DogStatsD
- Bumps some dependency versions