### PR TITLE
Fix bind error

### DIFF
--- a/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
+++ b/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
@@ -59,7 +59,7 @@ object Datadog {
     G: Async[G],
     F: ConcurrentEffect[F]
   ): Resource[F, Metrics[G]] =
-    Blocker[F].flatMap(SocketGroup[F]).flatMap(_.open(config.agentHost)).map { sock =>
+    Blocker[F].flatMap(SocketGroup[F]).flatMap(_.open()).map { sock =>
       new Metrics[G] {
         def counter(m: Metric): G[Long => G[Unit]] =
           G.pure(v => send[F, G](sock, config.agentHost, serialiseCounter(applyConfig(m, config), v)))


### PR DESCRIPTION
I forgot that the `config.agentHost` should not be used when opening the socket, only when sending packets