### PR TITLE
Upgrade to 2.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: |
             set -e
             tags=`git describe --tags`
-            sbt ';set version in ThisBuild := "'${tags}'"; test; publish'
+            sbt ';set version in ThisBuild := "'${tags}'"; +test; +publish'
       - *cache_save
 
   test:
@@ -45,7 +45,7 @@ jobs:
       - *cache_restore
       - run:
           name: Test
-          command: sbt test
+          command: sbt +test
       - *cache_save
 
 workflows:
@@ -62,4 +62,3 @@ workflows:
     jobs:
       - test:
           filters: {branches: {ignore: master}}
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: |
             set -e
             tags=`git describe --tags`
-            sbt ';set version in ThisBuild := "'${tags}'"; +test; +publish'
+            sbt ';set version in ThisBuild := "'${tags}'"; test; publish'
       - *cache_save
 
   test:
@@ -45,7 +45,7 @@ jobs:
       - *cache_restore
       - run:
           name: Test
-          command: sbt +test
+          command: sbt test
       - *cache_save
 
 workflows:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.bloop/
+.metals/
+metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 val common = Seq(
   ThisBuild / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.ScalaLibrary,
-  scalaVersion := "2.12.10",
-  crossScalaVersions := List(scalaVersion.value, "2.13.1"),
+  scalaVersion := "2.13.1",
   organization := "com.ovoenergy.effect",
   organizationName := "OVO Energy",
   organizationHomepage := Some(url("http://www.ovoenergy.com")),
@@ -107,7 +106,6 @@ lazy val root = (project in file("."))
   .settings(
     common ++ Seq(
       name := "effect-utils",
-      crossScalaVersions := Nil,
       publish := nop,
       publishLocal := nop
     ))

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 val common = Seq(
+  ThisBuild / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.ScalaLibrary,
   scalaVersion := "2.12.10",
+  crossScalaVersions := List(scalaVersion.value, "2.13.1"),
   organization := "com.ovoenergy.effect",
   organizationName := "OVO Energy",
   organizationHomepage := Some(url("http://www.ovoenergy.com")),
@@ -8,7 +10,7 @@ val common = Seq(
   licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   libraryDependencies ++= Seq(
     compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.10"),
+    compilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full),
     "org.typelevel" %% "cats-core" % "2.1.0",
     "org.typelevel" %% "cats-effect" % "2.1.0",
     "org.scalatest" %% "scalatest" % "3.0.8" % "test",
@@ -21,12 +23,13 @@ lazy val logging = project
   .settings(
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % "1.2.3",
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
     )
   )
 
 lazy val metricsCommon = project
   .in(file("metrics-common")).settings(common :+ (name := "metrics-common"))
+
 
 lazy val kamonMetrics = project
   .in(file("metrics-kamon"))
@@ -34,11 +37,11 @@ lazy val kamonMetrics = project
   .dependsOn(metricsCommon)
   .settings(
     libraryDependencies ++= Seq(
-      "io.kamon" %% "kamon-core" % "1.1.0"
+      "io.kamon" %% "kamon-core" % "2.0.5"
     )
   )
 
-val natchezVersion = "0.0.10"
+val natchezVersion = "0.0.11"
 val http4sVersion = "0.21.0-RC4"
 val circeVersion = "0.12.2"
 val fs2Version = "2.2.2"
@@ -76,7 +79,7 @@ lazy val natchezDoobie = project
   .settings(common :+ (name := "natchez-doobie"))
   .settings(
     libraryDependencies ++= Seq(
-      "org.tpolecat" %% "natchez-core" % "0.0.8",
+      "org.tpolecat" %% "natchez-core" % natchezVersion,
       "org.tpolecat" %% "doobie-core"  % "0.8.4",
       "org.tpolecat" %% "doobie-h2"    % "0.8.4",
       "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full,
@@ -101,7 +104,13 @@ lazy val datadogMetrics = project
   )
 
 lazy val root = (project in file("."))
-  .settings(common ++ Seq(name := "effect-utils", publish := nop, publishLocal := nop))
+  .settings(
+    common ++ Seq(
+      name := "effect-utils",
+      crossScalaVersions := Nil,
+      publish := nop,
+      publishLocal := nop
+    ))
   .aggregate(
     logging,
     metricsCommon,

--- a/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
+++ b/logging/src/main/scala/com/ovoenergy/effect/Logging.scala
@@ -8,8 +8,6 @@ import cats.syntax.functor._
 import Logging.Tags
 import org.slf4j.{LoggerFactory, MDC}
 
-import scala.language.higherKinds
-
 /**
  * A type class representing the ability to log
  * within some effect type F, with MDC information

--- a/metrics-kamon/src/main/scala/com/ovoenergy/effect/Kamon.scala
+++ b/metrics-kamon/src/main/scala/com/ovoenergy/effect/Kamon.scala
@@ -5,7 +5,7 @@ import cats.syntax.functor._
 import com.ovoenergy.effect.Metrics.Metric
 import kamon.{Kamon => K}
 
-import scala.language.higherKinds
+import kamon.tag.TagSet
 
 object Kamon {
 
@@ -16,16 +16,16 @@ object Kamon {
 
     def counter(metric: Metric): F[Long => F[Unit]] =
       Sync[F]
-        .delay(K.counter(metric.name).refine(metric.tags))
+        .delay(K.counter(metric.name).withTags(TagSet.from(metric.tags)))
         .map(
-          counter => times => Sync[F].delay(counter.increment(times))
+          counter => times => Sync[F].delay{ counter.increment(times); () }
         )
 
     def histogram(metric: Metric): F[Long => F[Unit]] =
       Sync[F]
-        .delay(K.histogram(metric.name).refine(metric.tags))
+        .delay(K.histogram(metric.name).withTags(TagSet.from(metric.tags)))
         .map(
-          histogram => duration => Sync[F].delay(histogram.record(duration))
+          histogram => duration => Sync[F].delay{ histogram.record(duration); () }
         )
   }
 }

--- a/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/DatadogSpan.scala
+++ b/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/DatadogSpan.scala
@@ -95,7 +95,7 @@ object DatadogSpan {
    */
   private def exitTags(exitCase: ExitCase[Throwable]): Map[String, String] =
     exitCase match {
-      case ExitCase.Error(e) => forThrowable(e).map{ case (k, v) => k -> v.value.toString }
+      case ExitCase.Error(e) => forThrowable(e).view.mapValues(_.value.toString).toMap
       case _ => Map.empty
     }
 
@@ -124,7 +124,7 @@ object DatadogSpan {
             parentId = datadogSpan.ids.parentId,
             error = isError(exitCase),
             meta = exitTags(exitCase) ++
-              meta.map{ case (k, v) => k -> v.value.toString }
+              meta.view.mapValues(_.value.toString).toMap
                 .updated("traceToken", datadogSpan.ids.traceToken)
           )
       }

--- a/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/DatadogSpan.scala
+++ b/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/DatadogSpan.scala
@@ -95,7 +95,7 @@ object DatadogSpan {
    */
   private def exitTags(exitCase: ExitCase[Throwable]): Map[String, String] =
     exitCase match {
-      case ExitCase.Error(e) => forThrowable(e).mapValues(_.value.toString)
+      case ExitCase.Error(e) => forThrowable(e).map{ case (k, v) => k -> v.value.toString }
       case _ => Map.empty
     }
 
@@ -124,7 +124,7 @@ object DatadogSpan {
             parentId = datadogSpan.ids.parentId,
             error = isError(exitCase),
             meta = exitTags(exitCase) ++
-              meta.mapValues(_.value.toString)
+              meta.map{ case (k, v) => k -> v.value.toString }
                 .updated("traceToken", datadogSpan.ids.traceToken)
           )
       }

--- a/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/DatadogTest.scala
+++ b/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/DatadogTest.scala
@@ -78,8 +78,8 @@ class DatadogTest extends WordSpec with Matchers {
       val rootSpan = spans.find(_.name == "bar").get
       val subSpan = spans.find(_.name == "sub").get
 
-      subSpan.meta.filterKeys(_ != "traceToken") shouldBe Map("foo" -> "bar", "baz" -> "qux")
-      rootSpan.meta.filterKeys(_ != "traceToken") shouldBe Map("foo" -> "bar")
+      subSpan.meta.filterNot{ case (k, _) => k === "traceToken" } shouldBe Map("foo" -> "bar", "baz" -> "qux")
+      rootSpan.meta.filterNot{ case (k, _) => k === "traceToken" } shouldBe Map("foo" -> "bar")
     }
   }
 }

--- a/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/DatadogTest.scala
+++ b/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/DatadogTest.scala
@@ -78,8 +78,8 @@ class DatadogTest extends WordSpec with Matchers {
       val rootSpan = spans.find(_.name == "bar").get
       val subSpan = spans.find(_.name == "sub").get
 
-      subSpan.meta.filterNot{ case (k, _) => k === "traceToken" } shouldBe Map("foo" -> "bar", "baz" -> "qux")
-      rootSpan.meta.filterNot{ case (k, _) => k === "traceToken" } shouldBe Map("foo" -> "bar")
+      subSpan.meta.view.filterKeys(_ != "traceToken").toMap shouldBe Map("foo" -> "bar", "baz" -> "qux")
+      rootSpan.meta.view.filterKeys(_ != "traceToken").toMap shouldBe Map("foo" -> "bar")
     }
   }
 }

--- a/natchez-slf4j/src/test/scala/com/ovoenergy/effect/natchez/Slf4jSpanTest.scala
+++ b/natchez-slf4j/src/test/scala/com/ovoenergy/effect/natchez/Slf4jSpanTest.scala
@@ -4,13 +4,13 @@ import cats.effect.{Concurrent, ContextShift, IO}
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import uk.org.lidalia.slf4jtest.{LoggingEvent, TestLoggerFactory}
 
-import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import cats.syntax.flatMap._
 import natchez.Kernel
 
 import scala.util.Try
-
+import scala.collection.mutable
+import JavaCollections._
 
 class Slf4jSpanTest extends WordSpec with Matchers with BeforeAndAfterEach {
 
@@ -71,4 +71,37 @@ class Slf4jSpanTest extends WordSpec with Matchers with BeforeAndAfterEach {
       res.unsafeRunSync.use(s => IO(s.token)).unsafeRunSync shouldBe "boz"
     }
   }
+
+}
+
+/**
+  * This is horrible, but it lets us workaround the fact that we need to compile under
+  * 2.12 and 2.13 and scala.collection.JavaConverters is deprecated in 2.13 and
+  * scala.jdk.ColletionConverters doesn't exist in 2.12...
+  */
+object JavaCollections {
+
+  implicit class JavaList[A](val list: java.util.List[A]) extends AnyVal {
+    def asScala: List[A] = {
+      val b = new mutable.ListBuffer[A]
+      val it = list.iterator()
+      while (it.hasNext()) {
+        b += it.next()
+      }
+      b.toList
+    }
+  }
+
+  implicit class JavaMap[A, B](val map: java.util.Map[A, B]) extends AnyVal {
+    def asScala: Map[A, B] = {
+      val b = new mutable.HashMap[A, B]
+      val it = map.entrySet().iterator()
+      while (it.hasNext()) {
+        val e = it.next()
+        b.put(e.getKey(), e.getValue())
+      }
+      b.toMap
+    }
+  }
+
 }

--- a/natchez-slf4j/src/test/scala/com/ovoenergy/effect/natchez/Slf4jSpanTest.scala
+++ b/natchez-slf4j/src/test/scala/com/ovoenergy/effect/natchez/Slf4jSpanTest.scala
@@ -5,12 +5,11 @@ import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import uk.org.lidalia.slf4jtest.{LoggingEvent, TestLoggerFactory}
 
 import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters._
 import cats.syntax.flatMap._
 import natchez.Kernel
 
 import scala.util.Try
-import scala.collection.mutable
-import JavaCollections._
 
 class Slf4jSpanTest extends WordSpec with Matchers with BeforeAndAfterEach {
 
@@ -69,38 +68,6 @@ class Slf4jSpanTest extends WordSpec with Matchers with BeforeAndAfterEach {
     "Succeed regardless of the case of the trace token" in {
       val res = Slf4jSpan.fromKernel[IO]("foo", Kernel(Map("x-Trace-TOKEN" -> "boz")))
       res.unsafeRunSync.use(s => IO(s.token)).unsafeRunSync shouldBe "boz"
-    }
-  }
-
-}
-
-/**
-  * This is horrible, but it lets us workaround the fact that we need to compile under
-  * 2.12 and 2.13 and scala.collection.JavaConverters is deprecated in 2.13 and
-  * scala.jdk.ColletionConverters doesn't exist in 2.12...
-  */
-object JavaCollections {
-
-  implicit class JavaList[A](val list: java.util.List[A]) extends AnyVal {
-    def asScala: List[A] = {
-      val b = new mutable.ListBuffer[A]
-      val it = list.iterator()
-      while (it.hasNext()) {
-        b += it.next()
-      }
-      b.toList
-    }
-  }
-
-  implicit class JavaMap[A, B](val map: java.util.Map[A, B]) extends AnyVal {
-    def asScala: Map[A, B] = {
-      val b = new mutable.HashMap[A, B]
-      val it = map.entrySet().iterator()
-      while (it.hasNext()) {
-        val e = it.next()
-        b.put(e.getKey(), e.getValue())
-      }
-      b.toMap
     }
   }
 


### PR DESCRIPTION
The project I'm working on uses Scala 2.13, so if I'm going to use the magical Datadog code contained herein, I need to build this library for 2.13. I had to upgrade a few dependency versions as well because the versions used before weren't all available for 2.13.

This is simpler than cross-building, and if anyone needs new features from this library, then they can upgrade to 2.12 (sorry to those people).