### PR TITLE
Natchez log4cats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,16 @@ lazy val natchezHttp4s = project
     )
   )
 
+lazy val natchezLog4Cats = project
+  .in(file("natchez-log4cats"))
+  .settings(common :+ (name := "natchez-log4cats"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.tpolecat" %% "natchez-core" % natchezVersion,
+      "io.chrisdavenport"    %% "log4cats-core" % "1.0.1"
+    )
+  )
+
 val silencerVersion = "1.6.0"
 val doobieVersion = "0.8.8"
 lazy val natchezDoobie = project
@@ -108,7 +118,8 @@ lazy val root = (project in file("."))
     natchezCombine,
     natchezSlf4j,
     natchezDoobie,
-    natchezHttp4s
+    natchezHttp4s,
+    natchezLog4Cats
   )
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/natchez-log4cats/src/main/scala/com/ovoenergy/effect/TracedLogger.scala
+++ b/natchez-log4cats/src/main/scala/com/ovoenergy/effect/TracedLogger.scala
@@ -1,12 +1,10 @@
 package com.ovoenergy.effect
 
+import cats.Monad
 import cats.data.Kleisli
 import cats.effect.Sync
-import cats.instances.option._
-import cats.syntax.apply._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import cats.{Functor, Monad}
 import io.chrisdavenport.log4cats.StructuredLogger
 import natchez.{Kernel, Span, Trace}
 
@@ -15,86 +13,78 @@ object TracedLogger {
   private def lowercaseHeaders(kernel: Kernel): Map[String, String] =
     kernel.toHeaders.map { case (k, v) => k.toLowerCase -> v }
 
-  private def findTraceId(headers: Map[String, String]): Option[String] =
-    headers
-      .get("x-trace-id")
-      .orElse(headers.get("trace_id"))
-      .orElse(headers.get("x-b3-traceid"))
-      .orElse(headers.get("traceid"))
-
-  private def findSpanId(headers: Map[String, String]): Option[String] =
-    headers
-      .get("x-parent-id")
-      .orElse(headers.get("x-span-id"))
-      .orElse(headers.get("span_id"))
-      .orElse(headers.get("x-b3-spanid"))
-      .orElse(headers.get("spanid"))
-
-  private def mdc[F[_]: Trace: Functor]: F[Map[String, String]] =
-    Trace[F].kernel.map { k =>
-      (
-        findTraceId(lowercaseHeaders(k)),
-        findSpanId(lowercaseHeaders(k))
-        ).mapN { case (traceId, spanId) =>
-        Map(
-          "trace_id" -> traceId,
-          "span_id" -> spanId
-        )
-      }.getOrElse(Map.empty)
-    }
+  /**
+   * Kernel to MDC for Datadog
+   * See docs at https://docs.datadoghq.com/logs/log_collection/java/?tab=log4j
+   */
+  private def datadogMdc(kernel: Kernel): Map[String, String] = {
+    val headers = lowercaseHeaders(kernel)
+    (
+      headers.get("x-parent-id").map("dd.span_id" -> _) ++
+      headers.get("x-trace-id").map("dd.trace_id" -> _)
+    ).toMap
+  }
 
   /**
    * Given a structured logger in some type F which does not have a trace instance
    * lift the logger into a Kleisli (so it then has a trace instance) and wrap it
    */
-  def lift[F[_]: Sync](l: StructuredLogger[F]): StructuredLogger[Kleisli[F, Span[F], *]] =
-    apply(l.mapK[Kleisli[F, Span[F], *]](Kleisli.liftK))
+  def lift[F[_]: Sync](
+    logger: StructuredLogger[F],
+    kernelMdc: Kernel => Map[String, String] = datadogMdc
+  ): StructuredLogger[Kleisli[F, Span[F], *]] =
+    apply(logger.mapK[Kleisli[F, Span[F], *]](Kleisli.liftK), kernelMdc)
 
   /**
    * Given a StructuredLogger wrap it into a new StructuredLogger
    * that extracts a trace_id and span_id from the Natchez Kernel and adds it to the MDC
    */
-  def apply[F[_]: Trace: Monad](l: StructuredLogger[F]): StructuredLogger[F] =
+  def apply[F[_]: Trace: Monad](
+    logger: StructuredLogger[F],
+    kernelMdc: Kernel => Map[String, String] = datadogMdc
+  ): StructuredLogger[F] =
     new StructuredLogger[F] {
+      val mdc: F[Map[String, String]] =
+        Trace[F].kernel.map(kernelMdc)
       def trace(ctx: Map[String, String])(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.trace(map ++ ctx)(msg))
+        mdc.flatMap(map => logger.trace(map ++ ctx)(msg))
       def trace(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.trace(map ++ ctx, t)(msg))
+        mdc.flatMap(map => logger.trace(map ++ ctx, t)(msg))
       def debug(ctx: Map[String, String])(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.debug(map ++ ctx)(msg))
+        mdc.flatMap(map => logger.debug(map ++ ctx)(msg))
       def debug(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.debug(map ++ ctx, t)(msg))
+        mdc.flatMap(map => logger.debug(map ++ ctx, t)(msg))
       def info(ctx: Map[String, String])(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.info(map ++ ctx)(msg))
+        mdc.flatMap(map => logger.info(map ++ ctx)(msg))
       def info(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.info(map ++ ctx, t)(msg))
+        mdc.flatMap(map => logger.info(map ++ ctx, t)(msg))
       def warn(ctx: Map[String, String])(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.warn(map ++ ctx)(msg))
+        mdc.flatMap(map => logger.warn(map ++ ctx)(msg))
       def warn(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.warn(map ++ ctx, t)(msg))
+        mdc.flatMap(map => logger.warn(map ++ ctx, t)(msg))
       def error(ctx: Map[String, String])(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.error(map ++ ctx)(msg))
+        mdc.flatMap(map => logger.error(map ++ ctx)(msg))
       def error(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
-        mdc[F].flatMap(map => l.error(map ++ ctx, t)(msg))
+        mdc.flatMap(map => logger.error(map ++ ctx, t)(msg))
       def error(t: Throwable)(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.error(map, t)(message))
+        mdc.flatMap(map => logger.error(map, t)(message))
       def warn(t: Throwable)(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.warn(map, t)(message))
+        mdc.flatMap(map => logger.warn(map, t)(message))
       def info(t: Throwable)(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.info(map, t)(message))
+        mdc.flatMap(map => logger.info(map, t)(message))
       def debug(t: Throwable)(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.debug(map, t)(message))
+        mdc.flatMap(map => logger.debug(map, t)(message))
       def trace(t: Throwable)(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.trace(map, t)(message))
+        mdc.flatMap(map => logger.trace(map, t)(message))
       def error(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.error(map)(message))
+        mdc.flatMap(map => logger.error(map)(message))
       def warn(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.warn(map)(message))
+        mdc.flatMap(map => logger.warn(map)(message))
       def info(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.info(map)(message))
+        mdc.flatMap(map => logger.info(map)(message))
       def debug(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.debug(map)(message))
+        mdc.flatMap(map => logger.debug(map)(message))
       def trace(message: => String): F[Unit] =
-        mdc[F].flatMap(map => l.trace(map)(message))
+        mdc.flatMap(map => logger.trace(map)(message))
     }
 }

--- a/natchez-log4cats/src/main/scala/com/ovoenergy/effect/TracedLogger.scala
+++ b/natchez-log4cats/src/main/scala/com/ovoenergy/effect/TracedLogger.scala
@@ -1,0 +1,100 @@
+package com.ovoenergy.effect
+
+import cats.data.Kleisli
+import cats.effect.Sync
+import cats.instances.option._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.{Functor, Monad}
+import io.chrisdavenport.log4cats.StructuredLogger
+import natchez.{Kernel, Span, Trace}
+
+object TracedLogger {
+
+  private def lowercaseHeaders(kernel: Kernel): Map[String, String] =
+    kernel.toHeaders.map { case (k, v) => k.toLowerCase -> v }
+
+  private def findTraceId(headers: Map[String, String]): Option[String] =
+    headers
+      .get("x-trace-id")
+      .orElse(headers.get("trace_id"))
+      .orElse(headers.get("x-b3-traceid"))
+      .orElse(headers.get("traceid"))
+
+  private def findSpanId(headers: Map[String, String]): Option[String] =
+    headers
+      .get("x-parent-id")
+      .orElse(headers.get("x-span-id"))
+      .orElse(headers.get("span_id"))
+      .orElse(headers.get("x-b3-spanid"))
+      .orElse(headers.get("spanid"))
+
+  private def mdc[F[_]: Trace: Functor]: F[Map[String, String]] =
+    Trace[F].kernel.map { k =>
+      (
+        findTraceId(lowercaseHeaders(k)),
+        findSpanId(lowercaseHeaders(k))
+        ).mapN { case (traceId, spanId) =>
+        Map(
+          "trace_id" -> traceId,
+          "span_id" -> spanId
+        )
+      }.getOrElse(Map.empty)
+    }
+
+  /**
+   * Given a structured logger in some type F which does not have a trace instance
+   * lift the logger into a Kleisli (so it then has a trace instance) and wrap it
+   */
+  def lift[F[_]: Sync](l: StructuredLogger[F]): StructuredLogger[Kleisli[F, Span[F], *]] =
+    apply(l.mapK[Kleisli[F, Span[F], *]](Kleisli.liftK))
+
+  /**
+   * Given a StructuredLogger wrap it into a new StructuredLogger
+   * that extracts a trace_id and span_id from the Natchez Kernel and adds it to the MDC
+   */
+  def apply[F[_]: Trace: Monad](l: StructuredLogger[F]): StructuredLogger[F] =
+    new StructuredLogger[F] {
+      def trace(ctx: Map[String, String])(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.trace(map ++ ctx)(msg))
+      def trace(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.trace(map ++ ctx, t)(msg))
+      def debug(ctx: Map[String, String])(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.debug(map ++ ctx)(msg))
+      def debug(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.debug(map ++ ctx, t)(msg))
+      def info(ctx: Map[String, String])(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.info(map ++ ctx)(msg))
+      def info(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.info(map ++ ctx, t)(msg))
+      def warn(ctx: Map[String, String])(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.warn(map ++ ctx)(msg))
+      def warn(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.warn(map ++ ctx, t)(msg))
+      def error(ctx: Map[String, String])(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.error(map ++ ctx)(msg))
+      def error(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+        mdc[F].flatMap(map => l.error(map ++ ctx, t)(msg))
+      def error(t: Throwable)(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.error(map, t)(message))
+      def warn(t: Throwable)(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.warn(map, t)(message))
+      def info(t: Throwable)(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.info(map, t)(message))
+      def debug(t: Throwable)(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.debug(map, t)(message))
+      def trace(t: Throwable)(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.trace(map, t)(message))
+      def error(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.error(map)(message))
+      def warn(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.warn(map)(message))
+      def info(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.info(map)(message))
+      def debug(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.debug(map)(message))
+      def trace(message: => String): F[Unit] =
+        mdc[F].flatMap(map => l.trace(map)(message))
+    }
+}


### PR DESCRIPTION
This is a small integration between Natchez & log4cats to allow us to pull headers from the Natchez `kernel` into the log4cats MDC so that in Datadog logs can be correlated with metrics

I didn't write any tests since this is so small, please forgive me!