### PR TITLE
Support span.type, prevent Datadog sampling traces

### DIFF
--- a/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/DatadogTags.scala
+++ b/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/DatadogTags.scala
@@ -11,6 +11,8 @@ object DatadogTags {
   sealed trait SpanType
 
   object SpanType {
+    case object Custom extends SpanType
+    case object Cache extends SpanType
     case object Web extends SpanType
     case object Db extends SpanType
   }
@@ -19,7 +21,7 @@ object DatadogTags {
     "env" -> env
 
   def spanType(spanType: SpanType): (String, TraceValue) =
-    "span.type" -> spanType.toString
+    "span.type" -> spanType.toString.toLowerCase
 
   def serviceName(name: String): (String, TraceValue) =
     "service.name" -> name

--- a/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/SubmittableSpan.scala
+++ b/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/SubmittableSpan.scala
@@ -1,0 +1,138 @@
+package com.ovoenergy.effect.natchez
+
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+import cats.Applicative
+import cats.effect.{Clock, ExitCase}
+import cats.syntax.apply._
+import com.ovoenergy.effect.natchez.DatadogTags.{SpanType, forThrowable}
+import io.circe.{Decoder, Encoder}
+import io.circe.Encoder.encodeString
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.semiauto._
+import natchez.TraceValue
+import natchez.TraceValue.StringValue
+
+/**
+ * This is the type we need to send to the Datadog agent
+ * to submit traces. Turning a span into one of these involves some trickery
+ * with tags, hence this being its own file now
+ */
+case class SubmittableSpan(
+  traceId: Long,
+  spanId: Long,
+  name: String,
+  service: String,
+  resource: String,
+  `type`: Option[SpanType],
+  start: Long,
+  duration: Long,
+  parentId: Option[Long],
+  error: Option[Int],
+  meta: Map[String, String],
+  metrics: Map[String, Double]
+)
+
+object SubmittableSpan {
+
+  implicit val config: Configuration =
+    Configuration.default.withSnakeCaseMemberNames
+
+  implicit val encodeSpanType: Encoder[SpanType] =
+    encodeString.contramap(_.toString.toLowerCase)
+
+  implicit val decodespanType: Decoder[Option[SpanType]] =
+    Decoder[Option[String]].map(_.flatMap(s => inferSpanType(Map("span.type" -> s))))
+
+  implicit val encode: Encoder[SubmittableSpan] =
+    deriveConfiguredEncoder
+
+  implicit val decode: Decoder[SubmittableSpan] =
+    deriveConfiguredDecoder
+
+  /**
+   * It is very difficult to find any docs on this other than this fun Github issue by fommil
+   * https://github.com/DataDog/datadog-agent/issues/3031 but setting this magic metric to 2
+   * means the Datadog Agent should always keep all our traces.
+   */
+  private val spanMetrics: Map[String, Double] =
+    Map("__sampling_priority_v1" -> 2.0d)
+
+  /**
+   * Datadog docs: "Set this [error] value to 1 to indicate if an error occurred"
+   */
+  private def isError[A](exitCase: ExitCase[A]): Option[Int] =
+    exitCase match {
+      case ExitCase.Completed => None
+      case ExitCase.Error(_)  => Some(1)
+      case ExitCase.Canceled  => None
+    }
+
+  /**
+   * Create some Datadog tags from an exit case,
+   * i.e. if the span failed include exception details
+   */
+  private def exitTags(exitCase: ExitCase[Throwable]): Map[String, String] =
+    exitCase match {
+      case ExitCase.Error(e) => forThrowable(e).view.mapValues(_.value.toString).toMap
+      case _                 => Map.empty
+    }
+
+  /**
+   * Sadly the only API we have to set span type is through tags
+   * so we just have to guess if the user tried to set it
+   */
+  private def inferSpanType(tags: Map[String, TraceValue]): Option[SpanType] =
+    tags.collectFirst {
+      case ("span.type", StringValue("cache")) => SpanType.Cache
+      case ("span.type", StringValue("web")) => SpanType.Web
+      case ("span.type", StringValue("db")) => SpanType.Db
+    }
+
+  /**
+   * Turn the Natchez tags into DataDog metadata.
+   * We filter out the magic span.type tag and add a trace token + error info
+   */
+  private def transformTags(
+    tags: Map[String, TraceValue],
+    exitCase: ExitCase[Throwable],
+    traceToken: String
+  ): Map[String, String] =
+    exitTags(exitCase) ++
+      tags
+        .view
+        .mapValues(_.value.toString)
+        .filterKeys(_ != "span.type")
+        .toMap
+        .updated("traceToken", traceToken)
+
+
+  /**
+   * Given an open DatadogSpan and an exit case to indicate whether the span succeeded
+   * Create a submittable span we can pass through to the DataDog agent API
+   */
+  def fromSpan[F[_]: Applicative: Clock](
+    span: DatadogSpan[F],
+    exitCase: ExitCase[Throwable]
+  ): F[SubmittableSpan] =
+    (
+      span.meta.get,
+      Clock[F].realTime(NANOSECONDS)
+      ).mapN {
+      case (meta, end) =>
+        SubmittableSpan(
+          traceId = span.ids.traceId,
+          spanId = span.ids.spanId,
+          name = span.names.name,
+          service = span.names.service,
+          resource = span.names.resource,
+          start = span.start,
+          duration = end - span.start,
+          parentId = span.ids.parentId,
+          error = isError(exitCase),
+          `type` = inferSpanType(meta),
+          metrics = spanMetrics,
+          meta = transformTags(meta, exitCase, span.ids.traceToken)
+        )
+    }
+}

--- a/natchez-doobie/src/test/scala/com/ovoenergy/effect/natchez/TracedTransactorTest.scala
+++ b/natchez-doobie/src/test/scala/com/ovoenergy/effect/natchez/TracedTransactorTest.scala
@@ -46,7 +46,7 @@ class TracedTransactorTest extends AnyWordSpec with Matchers {
     "Trace queries" in {
       val query = sql"SELECT 1 WHERE true = ${true: Boolean}".query[Int].unique
       val res = db.use(d => run(query.transact(d))).unsafeRunSync()
-      res.last shouldBe SpanData("test-db:db.execute:SELECT 1 WHERE true = ?", Map.empty)
+      res.last shouldBe SpanData("test-db:db.execute:SELECT 1 WHERE true = ?", Map("span.type" -> "db"))
     }
 
     "Trace updates" in {
@@ -54,7 +54,7 @@ class TracedTransactorTest extends AnyWordSpec with Matchers {
       val create = sql"CREATE TABLE a (id INT, name VARCHAR)".update.run
       val insert = sql"INSERT INTO a VALUES (${2: Int}, ${"abc": String})".update.run
       val res = db.use(d => run((create >> insert).transact(d))).unsafeRunSync()
-      res.last shouldBe SpanData("test-db:db.execute:INSERT INTO a VALUES (?, ?)", Map.empty)
+      res.last shouldBe SpanData("test-db:db.execute:INSERT INTO a VALUES (?, ?)", Map("span.type" -> "db"))
     }
   }
 }

--- a/natchez-http4s/src/main/scala/com/ovoenergy/effect/natchez/http4s/server/Configuration.scala
+++ b/natchez-http4s/src/main/scala/com/ovoenergy/effect/natchez/http4s/server/Configuration.scala
@@ -163,6 +163,7 @@ object Configuration {
     Configuration[F](
       request = uri[F]("http.url") |+|
         headers("http.request.headers")(isSensitive) |+|
+        const("span.type", "web") |+|
         method("http.method") |+|
         static,
       response = statusCode[F]("http.status_code") |+|

--- a/natchez-http4s/src/test/scala/com/ovoenergy/effect/natchez/http4s/server/TraceMiddlewareTest.scala
+++ b/natchez-http4s/src/test/scala/com/ovoenergy/effect/natchez/http4s/server/TraceMiddlewareTest.scala
@@ -67,6 +67,7 @@ class TraceMiddlewareTest extends AnyWordSpec with Matchers with Inspectors {
           _   <- svc.run(Request(headers = Headers.of(Header("X-Trace-Token", "foobar"))))
           tags <- entryPoint.tags
         } yield tags shouldBe Map(
+          "span.type" -> s("web"),
           "http.url" -> s("/"),
           "http.method" -> s("GET"),
           "http.status_code" -> NumberValue(200),
@@ -97,6 +98,7 @@ class TraceMiddlewareTest extends AnyWordSpec with Matchers with Inspectors {
           _   <- svc.run(Request(headers = requestHeaders))
           tags <- entryPoint.tags
         } yield tags shouldBe Map(
+          "span.type" -> s("web"),
           "http.url" -> s("/"),
           "http.method" -> s("GET"),
           "http.response.headers" -> s(""),
@@ -125,6 +127,7 @@ class TraceMiddlewareTest extends AnyWordSpec with Matchers with Inspectors {
           _   <- svc.run(Request())
           tags <- entryPoint.tags
         } yield tags shouldBe Map(
+          "span.type" -> s("web"),
           "http.method" -> s("GET"),
           "http.status_code" -> NumberValue(500),
           "http.response.entity" -> s("oh no"),
@@ -143,6 +146,7 @@ class TraceMiddlewareTest extends AnyWordSpec with Matchers with Inspectors {
           _   <- svc.run(Request())
           tags <- entryPoint.tags
         } yield tags shouldBe Map(
+          "span.type" -> s("web"),
           "http.method" -> s("GET"),
           "http.status_code" -> NumberValue(500),
           "http.response.headers" -> s(""),


### PR DESCRIPTION
This PR does three things

- Maps a `span.type` tag into a `type` field on when we submit traces to Datadog
- Adds a magic metric that _should_ prevent Datadog only keeping a sample of our traces\*
- Adds an `X-DataDog-Trace-Count` header to stop the agent logging warnings all the time

\* This could be made configurable in the future but none of the services using this library to my knowledge have enough traffic to require us to drop some traces