### PR TITLE
Add natchez-fs2 & natchez-testkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # effect-utils
 
-[ ![Download](https://api.bintray.com/packages/ovotech/maven/logging/images/download.svg) ](https://bintray.com/ovotech/maven/logging/_latestVersion)
+[ ![Download](https://api.bintray.com/packages/ovotech/maven/natchez-datadog/images/download.svg) ](https://bintray.com/ovotech/maven/logging/_latestVersion)
 
 This repository consists of a number of type classes which add behaviours to a generic `F[_]` type in your cats-effect projects.
 Each type class will be deployed to bintray as an independent jar to minimise transitive dependency issues if you only
@@ -18,3 +18,5 @@ Natchez Datadog | Integrates [natchez](https://github.com/tpolecat/natchez) with
 Natchez Doobie  | Integrates [natchez](https://github.com/tpolecat/natchez) with Doobie          | "com.ovoenergy.effect" % "natchez-doobie"
 Natchez SLF4J   | Integrates [natchez](https://github.com/tpolecat/natchez) with SLF4J           | "com.ovoenergy.effect" % "natchez-slf4j"
 Natchez Combine | Provides a function to combine two Natchez `EntryPoint[F]`s together           | "com.ovoenergy.effect" % "natchez-combine"
+Natchez FS2     | Provides an `AllocatedSpan` you submit manually for streams                    | "com.ovoenergy.effect" % "natchez-fs2"
+Natchez Testkit | Provides a `TestEntrypoint` backed by a `Ref` for unit tests                   | "com.ovoenergy.effect" % "natchez-testkit"

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 val common = Seq(
   ThisBuild / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.ScalaLibrary,
+  fork in Test := true,
   scalaVersion := "2.13.1",
   organization := "com.ovoenergy.effect",
   organizationName := "OVO Energy",

--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,27 @@ lazy val natchezLog4Cats = project
     )
   )
 
+lazy val natchezTestkit = project
+  .in(file("natchez-testkit"))
+  .settings(common :+ (name := "natchez-testkit"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.tpolecat" %% "natchez-core" % natchezVersion
+    )
+  )
+
+lazy val natchezFs2 = project
+  .in(file("natchez-fs2"))
+  .dependsOn(natchezTestkit)
+  .settings(common :+ (name := "natchez-fs2"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "kittens" % "2.0.0",
+      "org.tpolecat" %% "natchez-core" % natchezVersion,
+      "co.fs2" %% "fs2-core" % fs2Version
+    )
+  )
+
 val silencerVersion = "1.6.0"
 val doobieVersion = "0.8.8"
 lazy val natchezDoobie = project
@@ -119,7 +140,10 @@ lazy val root = (project in file("."))
     natchezSlf4j,
     natchezDoobie,
     natchezHttp4s,
-    natchezLog4Cats
+    natchezLog4Cats,
+    natchezHttp4s,
+    natchezFs2,
+    natchezTestkit
   )
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,6 @@ lazy val root = (project in file("."))
     natchezCombine,
     natchezSlf4j,
     natchezDoobie,
-    natchezHttp4s,
     natchezLog4Cats,
     natchezHttp4s,
     natchezFs2,

--- a/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/SubmittableSpan.scala
+++ b/natchez-datadog/src/main/scala/com/ovoenergy/effect/natchez/SubmittableSpan.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 import cats.Applicative
 import cats.effect.{Clock, ExitCase}
 import cats.syntax.apply._
-import com.ovoenergy.effect.natchez.DatadogTags.{SpanType, forThrowable}
+import com.ovoenergy.effect.natchez.DatadogTags.{forThrowable, SpanType}
 import io.circe.{Decoder, Encoder}
 import io.circe.Encoder.encodeString
 import io.circe.generic.extras.Configuration
@@ -85,8 +85,8 @@ object SubmittableSpan {
   private def inferSpanType(tags: Map[String, TraceValue]): Option[SpanType] =
     tags.collectFirst {
       case ("span.type", StringValue("cache")) => SpanType.Cache
-      case ("span.type", StringValue("web")) => SpanType.Web
-      case ("span.type", StringValue("db")) => SpanType.Db
+      case ("span.type", StringValue("web"))   => SpanType.Web
+      case ("span.type", StringValue("db"))    => SpanType.Db
     }
 
   /**
@@ -99,13 +99,11 @@ object SubmittableSpan {
     traceToken: String
   ): Map[String, String] =
     exitTags(exitCase) ++
-      tags
-        .view
-        .mapValues(_.value.toString)
-        .filterKeys(_ != "span.type")
-        .toMap
-        .updated("traceToken", traceToken)
-
+    tags.view
+      .mapValues(_.value.toString)
+      .filterKeys(_ != "span.type")
+      .toMap
+      .updated("traceToken", traceToken)
 
   /**
    * Given an open DatadogSpan and an exit case to indicate whether the span succeeded
@@ -118,7 +116,7 @@ object SubmittableSpan {
     (
       span.meta.get,
       Clock[F].realTime(NANOSECONDS)
-      ).mapN {
+    ).mapN {
       case (meta, end) =>
         SubmittableSpan(
           traceId = span.ids.traceId,

--- a/natchez-doobie/src/main/scala/com/ovoenergy/effect/natchez/TracedTransactor.scala
+++ b/natchez-doobie/src/main/scala/com/ovoenergy/effect/natchez/TracedTransactor.scala
@@ -41,9 +41,9 @@ object TracedTransactor {
                   Kleisli {
                     case TracedStatement(p, sql) =>
                       trace.span(s"$service-db:db.execute:${formatQuery(sql)}")(
-                      trace.put("span.type" -> "db") >>
-                      f(p)
-                    )
+                        trace.put("span.type" -> "db") >>
+                        f(p)
+                      )
                     case a =>
                       f(a)
                   }

--- a/natchez-fs2/src/main/scala/com/ovoenergy/effect/natchez/AllocatedSpan.scala
+++ b/natchez-fs2/src/main/scala/com/ovoenergy/effect/natchez/AllocatedSpan.scala
@@ -1,0 +1,112 @@
+package com.ovoenergy.effect.natchez
+
+import cats.Traverse
+import cats.effect.{Concurrent, Resource, Sync}
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import fs2.concurrent.Queue
+import fs2.{Pipe, Stream}
+import natchez.{Kernel, Span, TraceValue}
+
+/**
+ * A Natchez span that has been pre-allocated and will stay open
+ * until either the stream that created it terminates or you call submit
+ */
+trait AllocatedSpan[F[_]] extends Span[F] {
+
+  /**
+   * Add a task to run on calling submit. The added task will run before the span is submitted.
+   * If it fails any errors will be discarded and the span will then be submitted
+   */
+  def addSubmitTask(task: F[Unit]): AllocatedSpan[F]
+
+  /**
+   * Submit the span. The span should be considered invalid after this is called
+   * and no subspans should be created
+   */
+  def submit: F[Unit]
+}
+
+object AllocatedSpan {
+
+  /**
+   * Given a span broken out of a natchez resource
+   * create an AllocatedSpan that allows us to submit it
+   */
+  private def createSpan[F[_]](
+    spn: Span[F], submitTask: F[Unit]
+  )(implicit F: Sync[F]): AllocatedSpan[F] =
+    new AllocatedSpan[F] {
+      def kernel: F[Kernel] =
+        spn.kernel
+      def put(fields: (String, TraceValue)*): F[Unit] =
+        spn.put(fields:_*)
+      def span(name: String): Resource[F, Span[F]] =
+        spn.span(name)
+      def addSubmitTask(task: F[Unit]): AllocatedSpan[F] =
+        createSpan(spn, F.uncancelable(F.attempt(task) >> submit))
+      def submit: F[Unit] =
+        submitTask
+    }
+
+  /**
+   * Associate a value with an allocated span
+   */
+  case class Traced[F[_], A](
+    span: AllocatedSpan[F],
+    value: A
+  )
+
+  object Traced {
+    implicit def traverse[F[_]]: Traverse[Traced[F, *]] =
+      cats.derived.semi.traverse[Traced[F, *]]
+  }
+
+  /**
+   * Create an AllocatedSpan which breaks a span out of a Natchez resource
+   * and instead allows it to be submitted manually when committing Kafka messages
+   */
+  def create[F[_]: Concurrent, A](maxOpen: Int = 100)(
+    rootSpan: A => Resource[F, Span[F]]
+  )(implicit F: Sync[F]): Pipe[F, A, Traced[F, A]] = { stream =>
+    /*
+     * First we create an outer queue that receives tasks to run and
+     * passes them along to parEvalMap so that interruption of the outer stream we're piping
+     * will cause all the tasks to be cancelled
+     */
+    Stream
+      .eval(Queue.bounded[F, F[Unit]](maxSize = 1))
+      .flatMap { taskQueue =>
+        stream
+          .concurrently(taskQueue.dequeue.parEvalMapUnordered(maxOpen)(identity))
+          .evalMap { item =>
+            /*
+             * We then create two queues - one to dig the Span out of the resource and another
+             * that we use to block the resource from quitting until we say so,
+             * either with an error or a unit to indicate success
+             */
+            for {
+              out <- Queue.bounded[F, Span[F]](maxSize = 1)
+              halt <- Queue.bounded[F, Either[Throwable, Unit]](maxSize = 1)
+              task = rootSpan(item).use(out.enqueue1(_) >> halt.dequeue1.flatMap(F.fromEither))
+
+              /*
+               * we create a task that creates a span, submits it to our out queue
+               * and then blocks until we tell it to quit. We then pass that to
+               * the task queue  so it'll be cancelled only if the outer stream quits
+               */
+              _ <- taskQueue.enqueue1(task)
+
+              /*
+               * We then wait for the span we've dug out of the resource
+               * to come back from the task we've just submitted
+               */
+              s <- out.dequeue1
+            } yield Traced(
+              value = item,
+              span = createSpan(s, halt.enqueue1(Right(())))
+            )
+          }
+      }
+  }
+}

--- a/natchez-fs2/src/main/scala/com/ovoenergy/effect/natchez/AllocatedSpan.scala
+++ b/natchez-fs2/src/main/scala/com/ovoenergy/effect/natchez/AllocatedSpan.scala
@@ -34,13 +34,14 @@ object AllocatedSpan {
    * create an AllocatedSpan that allows us to submit it
    */
   private def createSpan[F[_]](
-    spn: Span[F], submitTask: F[Unit]
+    spn: Span[F],
+    submitTask: F[Unit]
   )(implicit F: Sync[F]): AllocatedSpan[F] =
     new AllocatedSpan[F] {
       def kernel: F[Kernel] =
         spn.kernel
       def put(fields: (String, TraceValue)*): F[Unit] =
-        spn.put(fields:_*)
+        spn.put(fields: _*)
       def span(name: String): Resource[F, Span[F]] =
         spn.span(name)
       def addSubmitTask(task: F[Unit]): AllocatedSpan[F] =
@@ -86,7 +87,7 @@ object AllocatedSpan {
              * either with an error or a unit to indicate success
              */
             for {
-              out <- Queue.bounded[F, Span[F]](maxSize = 1)
+              out  <- Queue.bounded[F, Span[F]](maxSize = 1)
               halt <- Queue.bounded[F, Either[Throwable, Unit]](maxSize = 1)
               task = rootSpan(item).use(out.enqueue1(_) >> halt.dequeue1.flatMap(F.fromEither))
 
@@ -102,10 +103,11 @@ object AllocatedSpan {
                * to come back from the task we've just submitted
                */
               s <- out.dequeue1
-            } yield Traced(
-              value = item,
-              span = createSpan(s, halt.enqueue1(Right(())))
-            )
+            } yield
+              Traced(
+                value = item,
+                span = createSpan(s, halt.enqueue1(Right(())))
+              )
           }
       }
   }

--- a/natchez-fs2/src/main/scala/com/ovoenergy/effect/natchez/syntax.scala
+++ b/natchez-fs2/src/main/scala/com/ovoenergy/effect/natchez/syntax.scala
@@ -1,0 +1,17 @@
+package com.ovoenergy.effect.natchez
+import cats.data.Kleisli
+import cats.effect.Sync
+import com.ovoenergy.effect.natchez.AllocatedSpan.Traced
+import cats.syntax.traverse._
+import fs2._
+import natchez.Span
+
+object syntax {
+
+  implicit class StreamOps[F[_]: Sync, A](s: Stream[F, Traced[F, A]]) {
+    def evalMapNamed[B](name: String)(op: A => F[B]): Stream[F, Traced[F, B]] =
+      s.evalMap(t => t.traverse(a => t.span.span(name).use(_ => op(a))))
+    def evalMapTraced[B](name: String)(op: A => Kleisli[F, Span[F], B]): Stream[F, Traced[F, B]] =
+      s.evalMap(t => t.traverse(a => t.span.span(name).use(op(a).run)))
+  }
+}

--- a/natchez-fs2/src/test/scala/com/ovoenergy/effect/natchez/AllocatedSpanTest.scala
+++ b/natchez-fs2/src/test/scala/com/ovoenergy/effect/natchez/AllocatedSpanTest.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import cats.effect.{Clock, ContextShift, ExitCase, IO, Timer}
 import fs2.Stream
-import org.scalactic.anyvals.PosInt
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/natchez-fs2/src/test/scala/com/ovoenergy/effect/natchez/AllocatedSpanTest.scala
+++ b/natchez-fs2/src/test/scala/com/ovoenergy/effect/natchez/AllocatedSpanTest.scala
@@ -1,0 +1,132 @@
+package com.ovoenergy.effect.natchez
+
+import java.util.UUID
+
+import cats.effect.{Clock, ContextShift, ExitCase, IO, Timer}
+import fs2.Stream
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.ExecutionContext
+
+class AllocatedSpanTest extends AnyWordSpec with Matchers {
+
+  implicit val cs: ContextShift[IO] =
+    IO.contextShift(ExecutionContext.global)
+
+  implicit val timer: Timer[IO] =
+    IO.timer(ExecutionContext.global)
+
+  implicit val clock: Clock[IO] =
+    Clock.extractFromTimer(timer)
+
+  val testEp: IO[TestEntryPoint[IO]] =
+    TestEntryPoint.apply[IO]
+
+
+  "AllocatedSpan.create" should {
+
+    "Submit the span even if a pre-submit task fails" in {
+      testEp
+        .flatMap { ep =>
+          val stream: IO[Unit] =
+            Stream
+              .emit("foo")
+              .covary[IO]
+              .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("root")))
+              .evalTap(_.span.addSubmitTask(IO.raiseError(new Exception)).submit)
+              .compile
+              .drain
+
+          for {
+            _ <- stream.attempt
+            spans <- ep.spans
+          } yield {
+            spans.length shouldBe 1
+            spans.maxBy(_.completed).name shouldBe "root"
+            Inspectors.forAll(spans)(_.exitCase shouldBe ExitCase.Completed)
+          }
+        }
+        .unsafeRunSync()
+    }
+
+
+    "Hold the parent span open until it is explicitly submitted" in {
+      testEp
+        .flatMap { ep =>
+          val stream: IO[Unit] =
+            Stream
+              .emit("foo")
+              .covary[IO]
+              .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("root")))
+              .evalTap(_.span.span("foo").use(_ => IO.unit))
+              .evalTap(_.span.submit)
+              .compile
+              .drain
+
+          for {
+            _ <- stream.attempt
+            spans <- ep.spans
+          } yield {
+            spans.length shouldBe 2
+            spans.minBy(_.completed).name shouldBe "foo"
+            spans.maxBy(_.completed).name shouldBe "root"
+            Inspectors.forAll(spans)(_.exitCase shouldBe ExitCase.Completed)
+          }
+        }
+        .unsafeRunSync()
+    }
+
+    "Cancel the allocated span if the stream dies" in {
+      testEp
+        .flatMap { ep =>
+          val stream: IO[Unit] =
+            Stream
+              .emit("foo")
+              .covary[IO]
+              .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("bar")))
+              .evalTap(_.span.span("foo").use(_ => IO.unit))
+              .evalTap(_ => IO.raiseError(new Exception("")))
+              .compile
+              .drain
+
+          for {
+            _ <- stream.attempt
+            spans <- ep.spans
+          } yield {
+            spans.length shouldBe 2
+            val last = spans.maxBy(_.completed)
+            val first = spans.minBy(_.completed)
+            last.exitCase shouldBe ExitCase.Canceled
+            first.exitCase shouldBe ExitCase.Completed
+          }
+        }
+        .unsafeRunSync()
+    }
+
+    "Work with extremely parallel streams" in {
+      testEp
+        .flatMap { ep =>
+          val stream: IO[Unit] =
+            Stream
+              .repeatEval(IO.delay(UUID.randomUUID()))
+              .take(50)
+              .through(AllocatedSpan.create(maxOpen = 10)(_ => ep.root("root")))
+              .parEvalMap(maxConcurrent = 50) { s =>
+                s.span.span("foo").use(_ => IO(s))
+              }
+              .evalMap(_.span.submit)
+              .compile
+              .drain
+
+          for {
+            _ <- stream.attempt
+            spans <- ep.spans
+          } yield spans.length shouldBe 100
+        }
+        .unsafeRunSync()
+    }
+  }
+}
+

--- a/natchez-http4s/src/main/scala/com/ovoenergy/effect/natchez/http4s/server/Configuration.scala
+++ b/natchez-http4s/src/main/scala/com/ovoenergy/effect/natchez/http4s/server/Configuration.scala
@@ -83,7 +83,7 @@ object Configuration {
     TagReader {
       Kleisli {
         case resp if !resp.status.isSuccess => tr.value.run(resp)
-        case _ => Applicative[F].pure(Map.empty)
+        case _                              => Applicative[F].pure(Map.empty)
       }
     }
 
@@ -97,8 +97,7 @@ object Configuration {
     TagReader.message { message =>
       Map(
         name -> StringValue(
-          message
-            .headers
+          message.headers
             .redactSensitive(redact)
             .foldLeft(new StringWriter) { case (sw, h) => h.render(sw).append('\n') }
             .result
@@ -113,10 +112,7 @@ object Configuration {
   def entity[F[_]: Sync](name: String): MessageReader[F] =
     TagReader(
       Kleisli { message =>
-        message
-          .bodyAsText
-          .compile
-          .last
+        message.bodyAsText.compile.last
           .map { body =>
             body.map(b => name -> StringValue(b)).toMap
           }
@@ -162,13 +158,13 @@ object Configuration {
     val static = defaults.toList.foldMap { case (k, v) => const[F](k, v) }
     Configuration[F](
       request = uri[F]("http.url") |+|
-        headers("http.request.headers")(isSensitive) |+|
-        const("span.type", "web") |+|
-        method("http.method") |+|
-        static,
+      headers("http.request.headers")(isSensitive) |+|
+      const("span.type", "web") |+|
+      method("http.method") |+|
+      static,
       response = statusCode[F]("http.status_code") |+|
-        headers("http.response.headers")(isSensitive) |+|
-        ifFailure(entity("http.response.entity"))
+      headers("http.response.headers")(isSensitive) |+|
+      ifFailure(entity("http.response.entity"))
     )
   }
 }

--- a/natchez-testkit/src/main/scala/com/ovoenergy/effect/natchez/TestEntryPoint.scala
+++ b/natchez-testkit/src/main/scala/com/ovoenergy/effect/natchez/TestEntryPoint.scala
@@ -1,0 +1,56 @@
+package com.ovoenergy.effect.natchez
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+import cats.effect.concurrent.Ref
+import cats.effect.{Clock, ExitCase, Resource, Sync}
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import com.ovoenergy.effect.natchez.TestEntryPoint.TestSpan
+import natchez.{EntryPoint, Kernel, Span, TraceValue}
+
+/**
+ * Test implementation of Natchez that is backed by a Ref
+ * and additionally lets you see all the completed spans
+ */
+trait TestEntryPoint[F[_]] extends EntryPoint[F] {
+  def spans: F[List[TestSpan]]
+}
+
+object TestEntryPoint {
+
+  case class TestSpan(
+    exitCase: ExitCase[Throwable],
+    parent: Option[String],
+    completed: Instant,
+    name: String
+  )
+
+  def apply[F[_]: Clock](implicit F: Sync[F]): F[TestEntryPoint[F]] =
+    Ref.of[F, List[TestSpan]](List.empty).map { submitted =>
+      def span(myName: String): Span[F] = new Span[F] {
+        def span(name: String): Resource[F, Span[F]] = makeSpan(name, Some(myName))
+        def put(fields: (String, TraceValue)*): F[Unit] = F.unit
+        def kernel: F[Kernel] = F.pure(Kernel(Map.empty))
+      }
+
+      def makeSpan(name: String, parent: Option[String]): Resource[F, Span[F]] =
+        Resource.makeCase(F.delay(span(name))) { (_, ec) =>
+          Clock[F]
+            .realTime(TimeUnit.MILLISECONDS)
+            .map(Instant.ofEpochMilli)
+            .flatMap { time =>
+              val span = TestSpan(ec, parent, time, name)
+              submitted.update(_ :+ span)
+            }
+        }
+
+      new TestEntryPoint[F] {
+        def spans: F[List[TestSpan]] = submitted.get
+        def root(name: String): Resource[F, Span[F]] = makeSpan(name, None)
+        def continue(name: String, k: Kernel): Resource[F, Span[F]] = makeSpan(name, None)
+        def continueOrElseRoot(name: String, k: Kernel): Resource[F, Span[F]] = makeSpan(name, None)
+      }
+    }
+}


### PR DESCRIPTION
These modules are a bit more experimental than the others but what `natchez-fs2` does is break `Span[F]` out of a `Resource[F, Span[F]]` and give you an `AllocatedSpan` that can be manually submitted as part of an FS2 stream, much like a committable Kafka Record in fs2-kafka