### PR TITLE
Events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,7 @@ lazy val datadogMetrics = project
   .dependsOn(metricsCommon)
   .settings(
     libraryDependencies ++= Seq(
+      "org.typelevel" %% "claimant" % "0.1.3" % Test,
       "co.fs2" %% "fs2-core" % fs2Version,
       "co.fs2" %% "fs2-io" % fs2Version,
     )

--- a/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
+++ b/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
@@ -59,7 +59,6 @@ object Datadog {
    * Datadog receives events as binary byte arrays then converts them into UTF-8 strings
    * https://github.com/DataDog/datadog-agent/blob/21a80ab80de389adb9c74e3e9a7162f83fda3e0c/pkg/dogstatsd/parse_events.go#L62
    * As such we obtain the byte values from the string in UTF-8
-   * We take only the first 2k chars just for a basic sanity check
    */
   private[effect] def filterEventText(s: String): UTF8Bytes =
     s.take(maxStringLength).toCharArray.flatMap {

--- a/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
+++ b/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
@@ -10,6 +10,19 @@ import fs2.io.udp._
 
 object Datadog {
 
+  // just for readability
+  type UTF8Bytes = Array[Byte]
+
+  private implicit class stringOps(s: String) {
+    def utf8Bytes: UTF8Bytes = s.getBytes("UTF-8")
+  }
+
+  private implicit class ByteArrayOps(bs: UTF8Bytes) {
+    def sep(char: Char)(other: UTF8Bytes): UTF8Bytes = (bs :+ char.toByte) ++ other
+    def colon: UTF8Bytes => UTF8Bytes = sep(':')
+    def pipe: UTF8Bytes => UTF8Bytes = sep('|')
+  }
+
   case class Config(
     agentHost: InetSocketAddress,
     metricPrefix: Option[String],
@@ -17,46 +30,63 @@ object Datadog {
   )
 
   /**
+   * Apparently the maximum UDP packet size is 65535 bytes (at the absolute maximum)
+   * and we have many different strings in a packet so we only allow each one to be 1Kb
+   */
+  val maxStringLength = 1000;
+
+  /**
+   * A basic sanity check for the maximum number of tags to send to Datadog
+   * 100 x 2000 (key + value size) = 20Kb so well within a reasonable budget
+   */
+  val maximumTagCount = 100
+
+  /**
    * Datadog enforces all metrics must start with a letter
    * and not contain any chars other than letters, numbers and underscores
    */
-  private[effect] def filterName(s: String): String =
-    s.dropWhile(!_.isLetter).replaceAll("[^A-Za-z0-9\\.]+", "_")
+  private[effect] def filterName(s: String): UTF8Bytes =
+    s.dropWhile(!_.isLetter).take(maxStringLength).replaceAll("[^A-Za-z0-9.]+", "_").utf8Bytes
 
   /**
    * More lenient filtering for tag values,
    * we allow alpha numeric characters, slashes, hyphens and numbers
    */
-  private[effect] def filterValue(s: String): String =
-    s.replaceAll("[^A-Za-z0-9\\./\\-]+", "_")
+  private[effect] def filterValue(s: String): UTF8Bytes =
+    s.replaceAll("[^A-Za-z0-9./\\-]+", "_").take(maxStringLength).utf8Bytes
 
   /**
-   * I am unsure what characters Datadog can handle
-   * so for now I am conservatively only allowing ASCII
-   * because with multibyte unicode chars I don't know what the length should be
+   * Datadog receives events as binary byte arrays then converts them into UTF-8 strings
+   * https://github.com/DataDog/datadog-agent/blob/21a80ab80de389adb9c74e3e9a7162f83fda3e0c/pkg/dogstatsd/parse_events.go#L62
+   * As such we obtain the byte values from the string in UTF-8
+   * We take only the first 2k chars just for a basic sanity check
    */
-  private[effect] def filterEventText(s: String): String =
-    s.flatMap {
-      case c if c == '\n' || c == '\r' => "\\n"
-      case c if c.toInt > 127 => " "
-      case c => c.toString
+  private[effect] def filterEventText(s: String): UTF8Bytes =
+    s.take(maxStringLength).toCharArray.flatMap {
+      case c if c == '\n' || c == '\r' => "\\n".utf8Bytes
+      case c => s"$c".utf8Bytes
     }
 
-  private def serialiseTags(t: Map[String, String]): String = {
-    val tagString = t.toList.map { case (k, v) => s"${filterName(k)}:${filterValue(v)}" }.mkString(",")
-    if (tagString.nonEmpty) s"|#$tagString" else ""
+  private def serialiseTags(t: Map[String, String]): UTF8Bytes = {
+    t.toList
+      .take(maximumTagCount)
+      .map { case (k, v) => filterName(k).colon(filterValue(v)) }
+      .reduceOption[UTF8Bytes] { case (a, b) => a.sep(',')(b) }
+      .fold(Array.empty[Byte])(bs => "|#".utf8Bytes ++ bs)
   }
 
-  private[effect] def serialiseCounter(m: Metric, value: Long): String =
-    s"${filterName(m.name)}:$value|c${serialiseTags(m.tags)}"
+  private[effect] def serialiseCounter(m: Metric, value: Long): UTF8Bytes =
+    filterName(m.name).colon(value.toString.utf8Bytes.pipe("c".utf8Bytes ++ serialiseTags(m.tags)))
 
-  private[effect] def serialiseHistogram(m: Metric, value: Long): String =
-    s"${filterName(m.name)}:$value|h|@1.0${serialiseTags(m.tags)}"
+  private[effect] def serialiseHistogram(m: Metric, value: Long): UTF8Bytes =
+    filterName(m.name).colon(value.toString.utf8Bytes.pipe("h|@1.0".utf8Bytes ++ serialiseTags(m.tags)))
 
-  private[effect] def serialiseEvent(e: Event): String = {
-    val body = filterEventText(e.body).take(1000)
-    val title = filterEventText(e.title).take(1000)
-    s"_e{${title.length},${body.length}}:$title|$body|t:${e.alertType.value}|p:${e.priority.value}${serialiseTags(e.tags)}"
+  private[effect] def serialiseEvent(e: Event): UTF8Bytes = {
+    val body = filterEventText(e.body)
+    val title = filterEventText(e.title)
+    val lengths = s"{${title.length},${body.length}}".utf8Bytes
+    val meta = s"t:${e.alertType.value}|p:${e.priority.value}".utf8Bytes
+    "_e".utf8Bytes ++ lengths.colon(title).pipe(body).pipe(meta ++ serialiseTags(e.tags))
   }
 
   private[effect] def applyConfig(m: Metric, config: Config): Metric =
@@ -66,8 +96,8 @@ object Datadog {
    * Take care of the gymnastics required to send a string to the `to` destination through
    * a socket in F before turning the resulting unit into a `G[Unit]` so our types line up
    */
-  private def send[F[_]: Effect, G[_]: Async](skt: Socket[F], to: InetSocketAddress, what: String): G[Unit] =
-    Async[G].liftIO(Effect[F].toIO(skt.write(Packet(to, array(what.getBytes)))))
+  private def send[F[_]: Effect, G[_]: Async](skt: Socket[F], to: InetSocketAddress, what: UTF8Bytes): G[Unit] =
+    Async[G].liftIO(Effect[F].toIO(skt.write(Packet(to, array(what)))))
 
   /**
    * Create an instance of Metrics that uses a UDP socket to communicate with Datadog.

--- a/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
+++ b/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
@@ -72,7 +72,7 @@ object Datadog {
    * As such we obtain the byte values from the string in UTF-8
    */
   private[effect] def filterEventText(s: String): UTF8Bytes =
-    s.take(maxStringLength).replaceAll("[\\r\\n]", "\\n").utf8Bytes
+    s.take(maxStringLength).replaceAll("[\\r\\n]", "\\\\n").utf8Bytes
 
   private def serialiseTags(t: Map[String, String]): UTF8Bytes = {
     t.toList

--- a/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
+++ b/metrics-datadog/src/main/scala/com/ovoenergy/effect/Datadog.scala
@@ -13,7 +13,7 @@ object Datadog {
   // just for readability
   type UTF8Bytes = Array[Byte]
 
-  private implicit class stringOps(s: String) {
+  private implicit class StringOps(s: String) {
     def utf8Bytes: UTF8Bytes = s.getBytes("UTF-8")
   }
 
@@ -33,7 +33,7 @@ object Datadog {
    * Apparently the maximum UDP packet size is 65535 bytes (at the absolute maximum)
    * and we have many different strings in a packet so we only allow each one to be 1Kb
    */
-  val maxStringLength = 1000;
+  val maxStringLength = 1000
 
   /**
    * A basic sanity check for the maximum number of tags to send to Datadog
@@ -46,7 +46,7 @@ object Datadog {
    * and not contain any chars other than letters, numbers and underscores
    */
   private[effect] def filterName(s: String): UTF8Bytes =
-    s.dropWhile(!_.isLetter).take(maxStringLength).replaceAll("[^A-Za-z0-9.]+", "_").utf8Bytes
+    s.dropWhile(!_.isLetter).replaceAll("[^A-Za-z0-9.]+", "_").take(maxStringLength).utf8Bytes
 
   /**
    * More lenient filtering for tag values,

--- a/metrics-datadog/src/main/scala/com/ovoenergy/effect/Events.scala
+++ b/metrics-datadog/src/main/scala/com/ovoenergy/effect/Events.scala
@@ -1,0 +1,51 @@
+package com.ovoenergy.effect
+
+import com.ovoenergy.effect.Events.Event
+
+/**
+ * Events are a Datadog extension to StatsD
+ * You can also send them over HTTP but since metrics are UDP
+ * we use the UDP approach here too
+ */
+trait Events[F[_]] {
+  def event(event: Event): F[Unit]
+}
+
+object Events {
+
+  sealed abstract class Priority(val value: String)
+
+  object Priority {
+    case object Normal extends Priority("normal")
+    case object Low extends Priority("low")
+  }
+
+  sealed abstract class AlertType(val value: String)
+
+  object AlertType {
+    case object Error extends AlertType("error")
+    case object Warning extends AlertType("warning")
+    case object Info extends AlertType("info")
+    case object Success extends AlertType("success")
+  }
+
+  case class Event(
+    title: String,
+    body: String,
+    alertType: AlertType,
+    tags: Map[String, String],
+    priority: Priority,
+  ) {
+    def withTags(tags: Map[String, String]): Event =
+      copy(tags = tags)
+    def withTag(name: String, value: String): Event =
+      copy(tags = tags.updated(name, value))
+    def prependTitle(name: String): Event =
+      copy(title = name + title)
+  }
+
+  object Event {
+    def forThrowable(t: Throwable): Event =
+      Event("Exception", t.getMessage, AlertType.Error, Map.empty, Priority.Normal)
+  }
+}

--- a/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
+++ b/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
@@ -1,7 +1,7 @@
 package com.ovoenergy.effect
 
 import java.net.InetSocketAddress
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 
 import com.ovoenergy.effect.Datadog._
 import com.ovoenergy.effect.Events.{AlertType, Event, Priority}
@@ -19,10 +19,10 @@ class DatadogTest extends AnyWordSpec with Matchers with Checkers {
     Arbitrary.arbString.arbitrary
 
   val bytes: Gen[Array[Byte]] =
-    string.map(_.getBytes("UTF-8"))
+    string.map(_.getBytes(UTF_8))
 
   def makeString(bytes: Array[Byte]) =
-    new String(bytes, StandardCharsets.UTF_8)
+    new String(bytes, UTF_8)
 
   val stringTags: Gen[Map[String, String]] =
     mapOf(Gen.zip(string, string))

--- a/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
+++ b/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
@@ -86,8 +86,8 @@ class DatadogTest extends AnyWordSpec with Matchers with Checkers {
     }
 
     "Generate correct events" in {
-      val res = serialiseEvent(Event("fooo", "bar", AlertType.Info, Map.empty, Priority.Normal))
-      makeString(res) shouldBe "_e{4,3}:fooo|bar|t:info|p:normal"
+      val res = serialiseEvent(Event("fooo", "bar\nbaz", AlertType.Info, Map.empty, Priority.Normal))
+      makeString(res) shouldBe "_e{4,8}:fooo|bar\\nbaz|t:info|p:normal"
     }
   }
 

--- a/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
+++ b/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
@@ -1,7 +1,7 @@
 package com.ovoenergy.effect
 
 import java.net.InetSocketAddress
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 import com.ovoenergy.effect.Datadog._
 import com.ovoenergy.effect.Events.{AlertType, Event, Priority}
@@ -22,7 +22,7 @@ class DatadogTest extends AnyWordSpec with Matchers with Checkers {
     string.map(_.getBytes("UTF-8"))
 
   def makeString(bytes: Array[Byte]) =
-    new String(bytes, Charset.forName("UTF-8"))
+    new String(bytes, StandardCharsets.UTF_8)
 
   val stringTags: Gen[Map[String, String]] =
     mapOf(Gen.zip(string, string))

--- a/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
+++ b/metrics-datadog/src/test/scala/com/ovoenergy/effect/DatadogTest.scala
@@ -3,6 +3,7 @@ package com.ovoenergy.effect
 import java.net.InetSocketAddress
 
 import com.ovoenergy.effect.Datadog._
+import com.ovoenergy.effect.Events.{AlertType, Event, Priority}
 import com.ovoenergy.effect.Metrics.Metric
 import org.scalacheck.Gen.mapOf
 import org.scalacheck.{Arbitrary, Gen, Prop}
@@ -64,6 +65,11 @@ class DatadogTest extends AnyWordSpec with Matchers with Checkers {
           serialiseCounter(Metric("foo", tags), 1) == s"foo:1|c|#$exp"
         }
       )
+    }
+
+    "Generate correct events" in {
+      val res = serialiseEvent(Event("fooo", "bar", AlertType.Info, Map.empty, Priority.Normal))
+      res shouldBe "_e{4,3}:fooo|bar|t:info|p:normal"
     }
   }
 


### PR DESCRIPTION
This PR adds support for Datadog Events

I'm doing this because I originally was struggling with creating a metric to alert when an application crashes unexpectedly and it seems to me an event is a more suitable thing to use than a metric & monitors as they aren't really good at dealing with, say, a counter that emits no metrics until it alerts (the monitor would always read `NO_DATA`)

Also with events you can post the error message + other useful information in whatever alerting channel you have which is pretty helpful for exceptions

I used the documentation https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics to figure out what we need to send the agent over UDP but it talks about string lengths without specifying whether they mean byte lengths or character / code point lengths - turns out in the agent code they're using bytes so I changed most of the serialization to work in bytes + UTF-8 strings for safety