### PR TITLE
Make agent host configurable, add error handling to submitter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val metricsCommon = project
 val natchezVersion = "0.0.11"
 val http4sVersion = "0.21.2"
 val circeVersion = "0.13.0"
+val slf4jVersion = "1.7.30"
 val fs2Version = "2.3.0"
 
 lazy val natchezDatadog = project
@@ -39,8 +40,9 @@ lazy val natchezDatadog = project
       "io.circe"     %% "circe-core"           % circeVersion,
       "io.circe"     %% "circe-generic"        % circeVersion,
       "io.circe"     %% "circe-generic-extras" % circeVersion,
-      "io.circe"     %% "circe-parser"         % circeVersion
-    )
+      "io.circe"     %% "circe-parser"         % circeVersion,
+      "org.slf4j"    % "slf4j-api"             % slf4jVersion
+)
   )
 
 lazy val natchezSlf4j = project
@@ -49,7 +51,7 @@ lazy val natchezSlf4j = project
   .settings(
     libraryDependencies ++= Seq(
       "org.tpolecat" %% "natchez-core" % natchezVersion,
-      "org.slf4j" % "slf4j-api" % "1.7.30",
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
       "uk.org.lidalia" % "slf4j-test" % "1.2.0" % Test
     )
   )

--- a/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/DatadogTest.scala
+++ b/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/DatadogTest.scala
@@ -53,7 +53,7 @@ class DatadogTest extends AnyWordSpec with Matchers {
       span.duration > 0 shouldBe true
       span.meta.get("k") shouldBe Some("v")
       span.metrics shouldBe Map("__sampling_priority_v1" -> 2.0)
-      span.meta.get("traceToken").isDefined shouldBe true
+      span.meta.contains("traceToken") shouldBe true
     }
 
     "Infer the right span.type from any tags set" in {

--- a/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/DatadogTest.scala
+++ b/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/DatadogTest.scala
@@ -1,19 +1,17 @@
 package com.ovoenergy.effect.natchez
 
 import cats.effect._
-import cats.effect.concurrent.Ref
 import cats.instances.list._
 import cats.syntax.flatMap._
-import cats.syntax.functor._
 import cats.syntax.traverse._
 import com.ovoenergy.effect.natchez.Datadog.entryPoint
 import com.ovoenergy.effect.natchez.DatadogTags.SpanType.{Cache, Db, Web}
 import com.ovoenergy.effect.natchez.DatadogTags.spanType
 import natchez.EntryPoint
 import natchez.TraceValue.StringValue
+import org.http4s.Request
 import org.http4s.circe.CirceEntityDecoder._
-import org.http4s.client.Client
-import org.http4s.{Request, Response}
+import org.http4s.syntax.literals._
 import org.scalatest.Inspectors
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -34,12 +32,39 @@ class DatadogTest extends AnyWordSpec with Matchers {
     IO.contextShift(global)
 
   def run(f: EntryPoint[IO] => IO[Unit]): IO[List[Request[IO]]] =
-    Ref.of[IO, List[Request[IO]]](List.empty).flatMap { ref =>
-      val client: Client[IO] = Client(r => Resource.liftF(ref.update(_ :+ r).as(Response[IO]())))
-      entryPoint(client, "test", "blah").use(f) >> ref.get
-    }
+    TestClient[IO].flatMap(c => entryPoint(c.client, "test", "blah").use(f) >> c.requests)
 
   "Datadog span" should {
+
+    "Obtain the agent host from the parameter" in {
+      (
+        for {
+          client <- TestClient[IO]
+          ep     = entryPoint(client.client, "a", "b", agentHost = uri"http://example.com")
+          _      <- ep.use(_.root("foo").use(_ => IO.unit))
+          requests <- client.requests
+        } yield requests.map(_.uri) shouldBe List(
+          uri"http://example.com/v0.3/traces"
+        )
+      ).unsafeRunSync()
+    }
+
+    "Continue to send HTTP calls even if one of them fails" in {
+
+      val test: EntryPoint[IO] => IO[Unit] =
+        ep => ep.root("first").use(_ => IO.unit) >>
+              IO.sleep(1.second) >>
+              ep.root("second").use(_ => IO.unit)
+      (
+        for {
+          client <- TestClient[IO]
+          _      <- client.respondWith(IO.raiseError(new Exception))
+          ep     = entryPoint(client.client, "a", "b", agentHost = uri"http://example.com")
+          _      <- ep.use(test)
+          requests <- client.requests
+        } yield requests.length shouldBe 2
+      ).unsafeRunSync()
+    }
 
     "Submit the right info to Datadog when closed" in {
 

--- a/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/TestClient.scala
+++ b/natchez-datadog/src/test/scala/com/ovoenergy/effect/natchez/TestClient.scala
@@ -1,0 +1,39 @@
+package com.ovoenergy.effect.natchez
+
+import cats.effect.concurrent.Ref
+import cats.effect.{Concurrent, Resource, Sync}
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import fs2.concurrent.Queue
+import org.http4s.client.Client
+import org.http4s.{Request, Response}
+
+
+trait TestClient[F[_]] {
+  def respondWith(resp: F[Response[F]]): F[Unit]
+  def requests: F[List[Request[F]]]
+  def client: Client[F]
+}
+
+object TestClient {
+
+  def apply[F[_]: Sync: Concurrent]: F[TestClient[F]]  =
+    (
+      Ref.of[F, List[Request[F]]](List.empty),
+      Queue.unbounded[F, F[Response[F]]]
+    ).mapN { case (reqs, resps) =>
+      new TestClient[F] {
+        def requests: F[List[Request[F]]] =
+          reqs.get
+        def respondWith(r: F[Response[F]]): F[Unit] =
+          resps.enqueue1(r)
+        def client: Client[F] =
+          Client { r =>
+            Resource.liftF(
+              reqs.update(_ :+ r) >>
+              resps.tryDequeue1.flatMap(r => r.getOrElse(Sync[F].pure(Response[F]())))
+            )
+          }
+      }
+    }
+}


### PR DESCRIPTION
This PR

- Adds an optional `agentHost` param for situations where the Datadog agent isn't running locally
- Warns when traces can't be submitted to Datadog or if the agent responds with a non 200
- Fixes the submitter stopping permanently if a submission to Datadog fails